### PR TITLE
Add premium color scheme palettes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,24 @@ Originally a pure black and white theme, True Dark has evolved into an elegant d
 - **Borders**: `#1E1E1E` (Subtle definition)
 - **Code Colors**: Pastel purples, blues, and greens for semantic grouping
 
+## 🌌 Premium Theme Variants
+
+The premium collection builds on True Dark and True Black foundations with unique accent palettes:
+
+- **True Dark Cool** / **True Black Cool**
+- **True Dark Warm** / **True Black Warm**
+- **True Dark Seasonal** / **True Black Seasonal**
+- **True Dark Space** / **True Black Space**
+- **True Dark Forest** / **True Black Forest**
+- **True Dark Dunes** / **True Black Dunes**
+- **True Dark Ruby** / **True Black Ruby**
+- **True Dark Premium** / **True Black Premium**
+
+- Each premium variant also includes its own editor color scheme so the accent
+  palette carries through to code highlighting. Keywords, numbers and comments
+  are all tinted to match each variant.
+
+
 ## Tips 🌟
 
 - **Use a modern font** like [JetBrains Mono](https://www.jetbrains.com/lp/mono/) or [Fira Code](https://github.com/tonsky/FiraCode)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -142,5 +142,21 @@
         <themeProvider id="ae7a917c-04b2-4468-bab7-6ddd4c43f879" path="/TrueBlack.theme.json"/>
         <themeProvider id="ae7a917c-04b2-4468-bdd8-6ddd4c43f879" path="/TrueDark.theme.json"/>
         <themeProvider id="ae7a917c-04b2-4468-bdd9-6ddd4c43f879" path="/TrueLight.theme.json"/>
+        <themeProvider id="c6a3caa7-7764-461a-9195-c4c9f3041c61" path="/TrueDarkCool.theme.json"/>
+        <themeProvider id="848a051c-6e91-443d-a5a9-b6acd5525017" path="/TrueDarkWarm.theme.json"/>
+        <themeProvider id="5b5913b9-738d-4de0-b46b-19867b508bc9" path="/TrueDarkSeasonal.theme.json"/>
+        <themeProvider id="36b36e33-6a8d-4d77-9cc5-42a31bb59fa9" path="/TrueDarkSpace.theme.json"/>
+        <themeProvider id="d334a05b-f0ba-487b-a8d4-205173f10bb4" path="/TrueDarkForest.theme.json"/>
+        <themeProvider id="21ada071-4768-47d1-b34a-771f75c99fe0" path="/TrueDarkDunes.theme.json"/>
+        <themeProvider id="60c5df6d-b314-47c6-a34c-7860ccb859b3" path="/TrueDarkRuby.theme.json"/>
+        <themeProvider id="e2508d5b-bfd5-4045-b234-e47221174297" path="/TrueDarkPremium.theme.json"/>
+        <themeProvider id="2fe2d7b2-e874-4469-84c7-5911d912e292" path="/TrueBlackCool.theme.json"/>
+        <themeProvider id="25fa2336-10ec-448b-91ce-d3bdce28b5cb" path="/TrueBlackWarm.theme.json"/>
+        <themeProvider id="22b132b5-c224-4106-ba23-b31465075d99" path="/TrueBlackSeasonal.theme.json"/>
+        <themeProvider id="ce1adf4a-6d9f-40d5-87c7-e0f14b383b67" path="/TrueBlackSpace.theme.json"/>
+        <themeProvider id="41461d3f-2d4f-4275-a9ac-94b69db8d826" path="/TrueBlackForest.theme.json"/>
+        <themeProvider id="e3695d26-3511-47b8-955f-f370b574f4f2" path="/TrueBlackDunes.theme.json"/>
+        <themeProvider id="0bbbf433-72fb-4374-8b63-958f4ba22fae" path="/TrueBlackRuby.theme.json"/>
+        <themeProvider id="853e0ea9-6588-4e50-84e0-d5549b8540c5" path="/TrueBlackPremium.theme.json"/>
     </extensions>
 </idea-plugin>

--- a/src/main/resources/TrueBlackCool.theme.json
+++ b/src/main/resources/TrueBlackCool.theme.json
@@ -1,0 +1,360 @@
+{
+  "name": "True Black Cool",
+  "dark": true,
+  "author": "Ahmed Elshaer",
+  "editorScheme": "/TrueBlackCool.xml",
+  "colors": {
+    "primary": "#000000",
+    "secondary": "#000000",
+    "activeSelection": "#505050",
+    "inactiveSelection": "#353535",
+    "borderColor": "#1c1c1c",
+    "separatorColor": "#1F1F1F",
+    "accentColor": "#5DB0FF"
+  },
+  "ui": {
+    "*": {
+      "arc": "6",
+      "background": "primary",
+      "selectionBackground": "activeSelection",
+      "selectionInactiveBackground": "inactiveSelection",
+      "disabledBackground": "primary",
+      "underlineColor": "accentColor",
+      "borderColor": "borderColor",
+      "separatorColor": "separatorColor",
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ActionButton": {
+      "hoverBorderColor": "accentColor",
+      "hoverBackground": "secondary",
+      "pressedBorderColor": "accentColor",
+      "pressedBackground": "secondary"
+    },
+    "Bookmark": {
+    },
+    "BookmarkMnemonicAssigned": {
+      "background": "inactiveSelection",
+      "borderColor": "inactiveSelection"
+    },
+    "BookmarkMnemonicCurrent": {
+      "background": "activeSelection",
+      "borderColor": "activeSelection"
+    },
+    "Borders": {
+      "color": "borderColor",
+      "ContrastBorderColor": "borderColor"
+    },
+    "Button": {
+      "foreground": "#D1D1D1",
+      "startBackground": "secondary",
+      "endBackground": "secondary",
+      "focusedBorderColor": "accentColor",
+      "startBorderColor": "inactiveSelection",
+      "endBorderColor": "inactiveSelection",
+      "default": {
+        "foreground": "#FFFFFF",
+        "startBackground": "accentColor",
+        "endBackground": "accentColor",
+        "startBorderColor": "accentColor",
+        "endBorderColor": "accentColor",
+        "focusColor": "accentColor",
+        "focusedBorderColor": "accentColor"
+      }
+    },
+    "Counter": {
+      "foreground": "#D1D1D1"
+    },
+    "TextField": {
+      "background": "primary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ComboBox": {
+      "nonEditableBackground": "secondary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "borderColor": "borderColor",
+      "ArrowButton": {
+        "background": "secondary",
+        "nonEditableBackground": "secondary"
+      }
+    },
+    "CompletionPopup": {
+      "matchForeground": "#fc5fa3",
+      "selectionBackground": "activeSelection",
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "Component": {
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor",
+      "disabledBorderColor": "borderColor"
+    },
+    "Editor": {
+      "shortcutForeground": "accentColor",
+      "background": "secondary",
+      "SearchField.borderColor": "borderColor",
+      "Tooltip.background": "inactiveSelection",
+      "Tooltip.borderColor": "borderColor",
+      "currentLineHighlight.style": "rounded",
+      "lineHighlight.borderRadius": 6,
+      "caretRow.style": "rounded"
+    },
+    "EditorTabs": {
+      "underlinedTabBackground": "primary",
+      "background": "secondary",
+      "underlineHeight": 2,
+      "tabArc": 6,
+      "underlineColor": "accentColor",
+      "selectedBackground": "activeSelection",
+      "selectedForeground": "accentColor",
+      "hoverBackground": "inactiveSelection"
+    },
+    "Link": {
+      "activeForeground": "accentColor",
+      "hoverForeground": "accentColor",
+      "visitedForeground": "#9F7AEA",
+      "pressedForeground": "accentColor"
+    },
+    "LoadingIndicator": {
+      "color": "#A78BFA",
+      "backgroundColor": "primary"
+    },
+    "Spinner": {
+      "background": "secondary",
+      "foreground": "#A78BFA",
+      "selectionForeground": "#C8A8E9"
+    },
+    "ProcessIndicator": {
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9"
+    },
+    "Notification": {
+      "ToolWindow": {
+        "informativeBackground": "primary",
+        "informativeBorderColor": "#42b827",
+        "informativeForeground": "#D1D1D1",
+        "warningBackground": "primary",
+        "errorBackground": "primary"
+      }
+    },
+    "Plugins": {
+      "hoverBackground": "accentColor",
+      "hoverForeground": "#FFFFFF",
+      "lightSelectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "foreground": "#D1D1D1"
+    },
+    "PasswordField": {
+      "background": "secondary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ProgressBar": {
+      "background": "primary",
+      "foreground": "#A78BFA",
+      "selectionBackground": "#B794F6",
+      "selectionForeground": "#C8A8E9",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "progressColor": "#A78BFA",
+      "trackColor": "inactiveSelection",
+      "passedColor": "#B794F6",
+      "passedEndColor": "#C8A8E9"
+    },
+    "SearchMatch": {
+      "startBackground": "#eeed38",
+      "endBackground": "#eeed38"
+    },
+    "SearchEverywhere": {
+      "Tab": {
+        "selectedBackground": "accentColor",
+        "selectedForeground": "#FFFFFF"
+      }
+    },
+    "SidePanel": {
+      "background": "secondary"
+    },
+    "StatusBar": {
+      "hoverBackground": "secondary"
+    },
+    "Table": {
+      "hoverBackground": "inactiveSelection",
+      "lightSelectionBackground": "accentColor",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverForeground": "#D1D1D1",
+      "gridColor": "borderColor"
+    },
+    "TableHeader": {
+      "bottomSeparatorColor": "separatorColor",
+      "borderColor": "borderColor"
+    },
+    "ToggleButton": {
+      "onBackground": "#D1D1D1"
+    },
+    "ToolWindow": {
+      "Button": {
+        "selectedBackground": "secondary"
+      },
+      "Header": {
+        "background": "primary",
+        "inactiveBackground": "secondary"
+      }
+    },
+    "Tree": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "foreground": "#D1D1D1",
+      "rowHeight": 22,
+      "selectionForeground": "#FFFFFF"
+    },
+    "VersionControl": {
+      "Log": {
+        "Commit": {
+          "currentBranchBackground": "accentColor",
+          "hoveredBackground": "inactiveSelection"
+        }
+      }
+    },
+    "WelcomeScreen": {
+      "SidePanel": {
+        "background": "secondary"
+      },
+      "Projects": {
+        "background": "inactiveSelection",
+        "actions": {
+          "background": "inactiveSelection"
+        }
+      }
+    },
+    "FileColor": {
+      "Yellow": "121212",
+      "Green": "121212",
+      "Blue": "121212",
+      "Violet": "121212",
+      "Orange": "121212",
+      "Rose": "121212"
+    },
+    "ProjectView": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "selectionForeground": "#FFFFFF"
+    },
+    "FileColors": {
+      "enabledForTabs": false,
+      "enabledForProjectView": false
+    },
+    "Scope": {
+      "background": "primary"
+    },
+    "Popup": {
+      "background": "primary",
+      "Header.activeBackground": "accentColor",
+      "Header.inactiveBackground": "inactiveSelection",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "Advertiser": {
+        "background": "inactiveSelection",
+        "borderColor": "borderColor"
+      }
+    },
+    "Breadcrumbs": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "hoverBackground": "inactiveSelection",
+      "borderColor": "borderColor",
+      "selectionForeground": "#FFFFFF"
+    },
+    "Menu": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "selectionBackground": "activeSelection"
+    },
+    "CheckBox": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "RadioButton": {
+      "background": "primary", 
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "FormattedTextField": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1"
+    },
+    "TextArea": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TextPane": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TaskProgressBar": {
+      "background": "primary",
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "passedColor": "#B794F6",
+      "trackColor": "inactiveSelection"
+    },
+    "InplaceRefactoringPopup": {
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "AsyncProcessIcon": {
+      "color": "#A78BFA"
+    },
+    "InternalFrameTitlePane": {
+      "background": "secondary",
+      "inactiveBackground": "primary"
+    },
+    "ScrollBar": {
+      "background": "primary",
+      "Thumb": {
+        "background": "inactiveSelection",
+        "hoverBackground": "accentColor",
+        "pressedBackground": "accentColor"
+      },
+      "track": "primary"
+    },
+    "Slider": {
+      "background": "primary",
+      "foreground": "accentColor",
+      "track": "inactiveSelection",
+      "thumb": "accentColor",
+      "focus": "accentColor"
+    },
+    "TabbedPane": {
+      "background": "secondary",
+      "selectedBackground": "accentColor",
+      "selectedForeground": "#FFFFFF",
+      "hoverColor": "inactiveSelection",
+      "focusColor": "accentColor",
+      "underlineColor": "accentColor",
+      "foreground": "#D1D1D1",
+      "hoverForeground": "#D1D1D1"
+    },
+    "List": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverBackground": "inactiveSelection"
+    }
+  }
+}

--- a/src/main/resources/TrueBlackCool.xml
+++ b/src/main/resources/TrueBlackCool.xml
@@ -1,0 +1,42 @@
+<scheme name="True Black Cool" version="142" parent_scheme="True Black">
+  <metaInfo>
+    <property name="created">2023-07-17T14:11:44</property>
+    <property name="ide">Idea</property>
+    <property name="ideVersion">231.9161.38</property>
+    <property name="modified">2023-07-17T14:11:44</property>
+    <property name="originalScheme">True Black</property>
+  </metaInfo>
+  <colors>
+    <option name="LINE_NUMBER_ON_CARET_ROW_COLOR" value="#5DB0FF" />
+    <option name="CARET_COLOR" value="#5DB0FF" />
+    <option name="SELECTION_BACKGROUND" value="#313131" />
+  </colors>
+  <attributes>
+    <option name="DEFAULT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="#5DB0FF" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_STRING">
+      <value>
+        <option name="FOREGROUND" value="#A1EFFF" />
+      </value>
+    </option>
+    <option name="DEFAULT_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="#2DDBD6" />
+      </value>
+    </option>
+    <option name="DEFAULT_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#6A9955" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#8293A8" />
+      </value>
+    </option>
+  </attributes>
+</scheme>

--- a/src/main/resources/TrueBlackDunes.theme.json
+++ b/src/main/resources/TrueBlackDunes.theme.json
@@ -1,0 +1,360 @@
+{
+  "name": "True Black Dunes",
+  "dark": true,
+  "author": "Ahmed Elshaer",
+  "editorScheme": "/TrueBlackDunes.xml",
+  "colors": {
+    "primary": "#000000",
+    "secondary": "#000000",
+    "activeSelection": "#505050",
+    "inactiveSelection": "#353535",
+    "borderColor": "#1c1c1c",
+    "separatorColor": "#1F1F1F",
+    "accentColor": "#D2B48C"
+  },
+  "ui": {
+    "*": {
+      "arc": "6",
+      "background": "primary",
+      "selectionBackground": "activeSelection",
+      "selectionInactiveBackground": "inactiveSelection",
+      "disabledBackground": "primary",
+      "underlineColor": "accentColor",
+      "borderColor": "borderColor",
+      "separatorColor": "separatorColor",
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ActionButton": {
+      "hoverBorderColor": "accentColor",
+      "hoverBackground": "secondary",
+      "pressedBorderColor": "accentColor",
+      "pressedBackground": "secondary"
+    },
+    "Bookmark": {
+    },
+    "BookmarkMnemonicAssigned": {
+      "background": "inactiveSelection",
+      "borderColor": "inactiveSelection"
+    },
+    "BookmarkMnemonicCurrent": {
+      "background": "activeSelection",
+      "borderColor": "activeSelection"
+    },
+    "Borders": {
+      "color": "borderColor",
+      "ContrastBorderColor": "borderColor"
+    },
+    "Button": {
+      "foreground": "#D1D1D1",
+      "startBackground": "secondary",
+      "endBackground": "secondary",
+      "focusedBorderColor": "accentColor",
+      "startBorderColor": "inactiveSelection",
+      "endBorderColor": "inactiveSelection",
+      "default": {
+        "foreground": "#FFFFFF",
+        "startBackground": "accentColor",
+        "endBackground": "accentColor",
+        "startBorderColor": "accentColor",
+        "endBorderColor": "accentColor",
+        "focusColor": "accentColor",
+        "focusedBorderColor": "accentColor"
+      }
+    },
+    "Counter": {
+      "foreground": "#D1D1D1"
+    },
+    "TextField": {
+      "background": "primary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ComboBox": {
+      "nonEditableBackground": "secondary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "borderColor": "borderColor",
+      "ArrowButton": {
+        "background": "secondary",
+        "nonEditableBackground": "secondary"
+      }
+    },
+    "CompletionPopup": {
+      "matchForeground": "#fc5fa3",
+      "selectionBackground": "activeSelection",
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "Component": {
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor",
+      "disabledBorderColor": "borderColor"
+    },
+    "Editor": {
+      "shortcutForeground": "accentColor",
+      "background": "secondary",
+      "SearchField.borderColor": "borderColor",
+      "Tooltip.background": "inactiveSelection",
+      "Tooltip.borderColor": "borderColor",
+      "currentLineHighlight.style": "rounded",
+      "lineHighlight.borderRadius": 6,
+      "caretRow.style": "rounded"
+    },
+    "EditorTabs": {
+      "underlinedTabBackground": "primary",
+      "background": "secondary",
+      "underlineHeight": 2,
+      "tabArc": 6,
+      "underlineColor": "accentColor",
+      "selectedBackground": "activeSelection",
+      "selectedForeground": "accentColor",
+      "hoverBackground": "inactiveSelection"
+    },
+    "Link": {
+      "activeForeground": "accentColor",
+      "hoverForeground": "accentColor",
+      "visitedForeground": "#9F7AEA",
+      "pressedForeground": "accentColor"
+    },
+    "LoadingIndicator": {
+      "color": "#A78BFA",
+      "backgroundColor": "primary"
+    },
+    "Spinner": {
+      "background": "secondary",
+      "foreground": "#A78BFA",
+      "selectionForeground": "#C8A8E9"
+    },
+    "ProcessIndicator": {
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9"
+    },
+    "Notification": {
+      "ToolWindow": {
+        "informativeBackground": "primary",
+        "informativeBorderColor": "#42b827",
+        "informativeForeground": "#D1D1D1",
+        "warningBackground": "primary",
+        "errorBackground": "primary"
+      }
+    },
+    "Plugins": {
+      "hoverBackground": "accentColor",
+      "hoverForeground": "#FFFFFF",
+      "lightSelectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "foreground": "#D1D1D1"
+    },
+    "PasswordField": {
+      "background": "secondary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ProgressBar": {
+      "background": "primary",
+      "foreground": "#A78BFA",
+      "selectionBackground": "#B794F6",
+      "selectionForeground": "#C8A8E9",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "progressColor": "#A78BFA",
+      "trackColor": "inactiveSelection",
+      "passedColor": "#B794F6",
+      "passedEndColor": "#C8A8E9"
+    },
+    "SearchMatch": {
+      "startBackground": "#eeed38",
+      "endBackground": "#eeed38"
+    },
+    "SearchEverywhere": {
+      "Tab": {
+        "selectedBackground": "accentColor",
+        "selectedForeground": "#FFFFFF"
+      }
+    },
+    "SidePanel": {
+      "background": "secondary"
+    },
+    "StatusBar": {
+      "hoverBackground": "secondary"
+    },
+    "Table": {
+      "hoverBackground": "inactiveSelection",
+      "lightSelectionBackground": "accentColor",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverForeground": "#D1D1D1",
+      "gridColor": "borderColor"
+    },
+    "TableHeader": {
+      "bottomSeparatorColor": "separatorColor",
+      "borderColor": "borderColor"
+    },
+    "ToggleButton": {
+      "onBackground": "#D1D1D1"
+    },
+    "ToolWindow": {
+      "Button": {
+        "selectedBackground": "secondary"
+      },
+      "Header": {
+        "background": "primary",
+        "inactiveBackground": "secondary"
+      }
+    },
+    "Tree": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "foreground": "#D1D1D1",
+      "rowHeight": 22,
+      "selectionForeground": "#FFFFFF"
+    },
+    "VersionControl": {
+      "Log": {
+        "Commit": {
+          "currentBranchBackground": "accentColor",
+          "hoveredBackground": "inactiveSelection"
+        }
+      }
+    },
+    "WelcomeScreen": {
+      "SidePanel": {
+        "background": "secondary"
+      },
+      "Projects": {
+        "background": "inactiveSelection",
+        "actions": {
+          "background": "inactiveSelection"
+        }
+      }
+    },
+    "FileColor": {
+      "Yellow": "121212",
+      "Green": "121212",
+      "Blue": "121212",
+      "Violet": "121212",
+      "Orange": "121212",
+      "Rose": "121212"
+    },
+    "ProjectView": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "selectionForeground": "#FFFFFF"
+    },
+    "FileColors": {
+      "enabledForTabs": false,
+      "enabledForProjectView": false
+    },
+    "Scope": {
+      "background": "primary"
+    },
+    "Popup": {
+      "background": "primary",
+      "Header.activeBackground": "accentColor",
+      "Header.inactiveBackground": "inactiveSelection",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "Advertiser": {
+        "background": "inactiveSelection",
+        "borderColor": "borderColor"
+      }
+    },
+    "Breadcrumbs": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "hoverBackground": "inactiveSelection",
+      "borderColor": "borderColor",
+      "selectionForeground": "#FFFFFF"
+    },
+    "Menu": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "selectionBackground": "activeSelection"
+    },
+    "CheckBox": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "RadioButton": {
+      "background": "primary", 
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "FormattedTextField": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1"
+    },
+    "TextArea": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TextPane": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TaskProgressBar": {
+      "background": "primary",
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "passedColor": "#B794F6",
+      "trackColor": "inactiveSelection"
+    },
+    "InplaceRefactoringPopup": {
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "AsyncProcessIcon": {
+      "color": "#A78BFA"
+    },
+    "InternalFrameTitlePane": {
+      "background": "secondary",
+      "inactiveBackground": "primary"
+    },
+    "ScrollBar": {
+      "background": "primary",
+      "Thumb": {
+        "background": "inactiveSelection",
+        "hoverBackground": "accentColor",
+        "pressedBackground": "accentColor"
+      },
+      "track": "primary"
+    },
+    "Slider": {
+      "background": "primary",
+      "foreground": "accentColor",
+      "track": "inactiveSelection",
+      "thumb": "accentColor",
+      "focus": "accentColor"
+    },
+    "TabbedPane": {
+      "background": "secondary",
+      "selectedBackground": "accentColor",
+      "selectedForeground": "#FFFFFF",
+      "hoverColor": "inactiveSelection",
+      "focusColor": "accentColor",
+      "underlineColor": "accentColor",
+      "foreground": "#D1D1D1",
+      "hoverForeground": "#D1D1D1"
+    },
+    "List": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverBackground": "inactiveSelection"
+    }
+  }
+}

--- a/src/main/resources/TrueBlackDunes.xml
+++ b/src/main/resources/TrueBlackDunes.xml
@@ -1,0 +1,42 @@
+<scheme name="True Black Dunes" version="142" parent_scheme="True Black">
+  <metaInfo>
+    <property name="created">2023-07-17T14:11:44</property>
+    <property name="ide">Idea</property>
+    <property name="ideVersion">231.9161.38</property>
+    <property name="modified">2023-07-17T14:11:44</property>
+    <property name="originalScheme">True Black</property>
+  </metaInfo>
+  <colors>
+    <option name="LINE_NUMBER_ON_CARET_ROW_COLOR" value="#D2B48C" />
+    <option name="CARET_COLOR" value="#D2B48C" />
+    <option name="SELECTION_BACKGROUND" value="#313131" />
+  </colors>
+  <attributes>
+    <option name="DEFAULT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="#D2B48C" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_STRING">
+      <value>
+        <option name="FOREGROUND" value="#F0E68C" />
+      </value>
+    </option>
+    <option name="DEFAULT_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="#D4B483" />
+      </value>
+    </option>
+    <option name="DEFAULT_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#A18860" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#C8B699" />
+      </value>
+    </option>
+  </attributes>
+</scheme>

--- a/src/main/resources/TrueBlackForest.theme.json
+++ b/src/main/resources/TrueBlackForest.theme.json
@@ -1,0 +1,360 @@
+{
+  "name": "True Black Forest",
+  "dark": true,
+  "author": "Ahmed Elshaer",
+  "editorScheme": "/TrueBlackForest.xml",
+  "colors": {
+    "primary": "#000000",
+    "secondary": "#000000",
+    "activeSelection": "#505050",
+    "inactiveSelection": "#353535",
+    "borderColor": "#1c1c1c",
+    "separatorColor": "#1F1F1F",
+    "accentColor": "#81C784"
+  },
+  "ui": {
+    "*": {
+      "arc": "6",
+      "background": "primary",
+      "selectionBackground": "activeSelection",
+      "selectionInactiveBackground": "inactiveSelection",
+      "disabledBackground": "primary",
+      "underlineColor": "accentColor",
+      "borderColor": "borderColor",
+      "separatorColor": "separatorColor",
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ActionButton": {
+      "hoverBorderColor": "accentColor",
+      "hoverBackground": "secondary",
+      "pressedBorderColor": "accentColor",
+      "pressedBackground": "secondary"
+    },
+    "Bookmark": {
+    },
+    "BookmarkMnemonicAssigned": {
+      "background": "inactiveSelection",
+      "borderColor": "inactiveSelection"
+    },
+    "BookmarkMnemonicCurrent": {
+      "background": "activeSelection",
+      "borderColor": "activeSelection"
+    },
+    "Borders": {
+      "color": "borderColor",
+      "ContrastBorderColor": "borderColor"
+    },
+    "Button": {
+      "foreground": "#D1D1D1",
+      "startBackground": "secondary",
+      "endBackground": "secondary",
+      "focusedBorderColor": "accentColor",
+      "startBorderColor": "inactiveSelection",
+      "endBorderColor": "inactiveSelection",
+      "default": {
+        "foreground": "#FFFFFF",
+        "startBackground": "accentColor",
+        "endBackground": "accentColor",
+        "startBorderColor": "accentColor",
+        "endBorderColor": "accentColor",
+        "focusColor": "accentColor",
+        "focusedBorderColor": "accentColor"
+      }
+    },
+    "Counter": {
+      "foreground": "#D1D1D1"
+    },
+    "TextField": {
+      "background": "primary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ComboBox": {
+      "nonEditableBackground": "secondary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "borderColor": "borderColor",
+      "ArrowButton": {
+        "background": "secondary",
+        "nonEditableBackground": "secondary"
+      }
+    },
+    "CompletionPopup": {
+      "matchForeground": "#fc5fa3",
+      "selectionBackground": "activeSelection",
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "Component": {
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor",
+      "disabledBorderColor": "borderColor"
+    },
+    "Editor": {
+      "shortcutForeground": "accentColor",
+      "background": "secondary",
+      "SearchField.borderColor": "borderColor",
+      "Tooltip.background": "inactiveSelection",
+      "Tooltip.borderColor": "borderColor",
+      "currentLineHighlight.style": "rounded",
+      "lineHighlight.borderRadius": 6,
+      "caretRow.style": "rounded"
+    },
+    "EditorTabs": {
+      "underlinedTabBackground": "primary",
+      "background": "secondary",
+      "underlineHeight": 2,
+      "tabArc": 6,
+      "underlineColor": "accentColor",
+      "selectedBackground": "activeSelection",
+      "selectedForeground": "accentColor",
+      "hoverBackground": "inactiveSelection"
+    },
+    "Link": {
+      "activeForeground": "accentColor",
+      "hoverForeground": "accentColor",
+      "visitedForeground": "#9F7AEA",
+      "pressedForeground": "accentColor"
+    },
+    "LoadingIndicator": {
+      "color": "#A78BFA",
+      "backgroundColor": "primary"
+    },
+    "Spinner": {
+      "background": "secondary",
+      "foreground": "#A78BFA",
+      "selectionForeground": "#C8A8E9"
+    },
+    "ProcessIndicator": {
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9"
+    },
+    "Notification": {
+      "ToolWindow": {
+        "informativeBackground": "primary",
+        "informativeBorderColor": "#42b827",
+        "informativeForeground": "#D1D1D1",
+        "warningBackground": "primary",
+        "errorBackground": "primary"
+      }
+    },
+    "Plugins": {
+      "hoverBackground": "accentColor",
+      "hoverForeground": "#FFFFFF",
+      "lightSelectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "foreground": "#D1D1D1"
+    },
+    "PasswordField": {
+      "background": "secondary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ProgressBar": {
+      "background": "primary",
+      "foreground": "#A78BFA",
+      "selectionBackground": "#B794F6",
+      "selectionForeground": "#C8A8E9",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "progressColor": "#A78BFA",
+      "trackColor": "inactiveSelection",
+      "passedColor": "#B794F6",
+      "passedEndColor": "#C8A8E9"
+    },
+    "SearchMatch": {
+      "startBackground": "#eeed38",
+      "endBackground": "#eeed38"
+    },
+    "SearchEverywhere": {
+      "Tab": {
+        "selectedBackground": "accentColor",
+        "selectedForeground": "#FFFFFF"
+      }
+    },
+    "SidePanel": {
+      "background": "secondary"
+    },
+    "StatusBar": {
+      "hoverBackground": "secondary"
+    },
+    "Table": {
+      "hoverBackground": "inactiveSelection",
+      "lightSelectionBackground": "accentColor",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverForeground": "#D1D1D1",
+      "gridColor": "borderColor"
+    },
+    "TableHeader": {
+      "bottomSeparatorColor": "separatorColor",
+      "borderColor": "borderColor"
+    },
+    "ToggleButton": {
+      "onBackground": "#D1D1D1"
+    },
+    "ToolWindow": {
+      "Button": {
+        "selectedBackground": "secondary"
+      },
+      "Header": {
+        "background": "primary",
+        "inactiveBackground": "secondary"
+      }
+    },
+    "Tree": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "foreground": "#D1D1D1",
+      "rowHeight": 22,
+      "selectionForeground": "#FFFFFF"
+    },
+    "VersionControl": {
+      "Log": {
+        "Commit": {
+          "currentBranchBackground": "accentColor",
+          "hoveredBackground": "inactiveSelection"
+        }
+      }
+    },
+    "WelcomeScreen": {
+      "SidePanel": {
+        "background": "secondary"
+      },
+      "Projects": {
+        "background": "inactiveSelection",
+        "actions": {
+          "background": "inactiveSelection"
+        }
+      }
+    },
+    "FileColor": {
+      "Yellow": "121212",
+      "Green": "121212",
+      "Blue": "121212",
+      "Violet": "121212",
+      "Orange": "121212",
+      "Rose": "121212"
+    },
+    "ProjectView": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "selectionForeground": "#FFFFFF"
+    },
+    "FileColors": {
+      "enabledForTabs": false,
+      "enabledForProjectView": false
+    },
+    "Scope": {
+      "background": "primary"
+    },
+    "Popup": {
+      "background": "primary",
+      "Header.activeBackground": "accentColor",
+      "Header.inactiveBackground": "inactiveSelection",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "Advertiser": {
+        "background": "inactiveSelection",
+        "borderColor": "borderColor"
+      }
+    },
+    "Breadcrumbs": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "hoverBackground": "inactiveSelection",
+      "borderColor": "borderColor",
+      "selectionForeground": "#FFFFFF"
+    },
+    "Menu": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "selectionBackground": "activeSelection"
+    },
+    "CheckBox": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "RadioButton": {
+      "background": "primary", 
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "FormattedTextField": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1"
+    },
+    "TextArea": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TextPane": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TaskProgressBar": {
+      "background": "primary",
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "passedColor": "#B794F6",
+      "trackColor": "inactiveSelection"
+    },
+    "InplaceRefactoringPopup": {
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "AsyncProcessIcon": {
+      "color": "#A78BFA"
+    },
+    "InternalFrameTitlePane": {
+      "background": "secondary",
+      "inactiveBackground": "primary"
+    },
+    "ScrollBar": {
+      "background": "primary",
+      "Thumb": {
+        "background": "inactiveSelection",
+        "hoverBackground": "accentColor",
+        "pressedBackground": "accentColor"
+      },
+      "track": "primary"
+    },
+    "Slider": {
+      "background": "primary",
+      "foreground": "accentColor",
+      "track": "inactiveSelection",
+      "thumb": "accentColor",
+      "focus": "accentColor"
+    },
+    "TabbedPane": {
+      "background": "secondary",
+      "selectedBackground": "accentColor",
+      "selectedForeground": "#FFFFFF",
+      "hoverColor": "inactiveSelection",
+      "focusColor": "accentColor",
+      "underlineColor": "accentColor",
+      "foreground": "#D1D1D1",
+      "hoverForeground": "#D1D1D1"
+    },
+    "List": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverBackground": "inactiveSelection"
+    }
+  }
+}

--- a/src/main/resources/TrueBlackForest.xml
+++ b/src/main/resources/TrueBlackForest.xml
@@ -1,0 +1,42 @@
+<scheme name="True Black Forest" version="142" parent_scheme="True Black">
+  <metaInfo>
+    <property name="created">2023-07-17T14:11:44</property>
+    <property name="ide">Idea</property>
+    <property name="ideVersion">231.9161.38</property>
+    <property name="modified">2023-07-17T14:11:44</property>
+    <property name="originalScheme">True Black</property>
+  </metaInfo>
+  <colors>
+    <option name="LINE_NUMBER_ON_CARET_ROW_COLOR" value="#81C784" />
+    <option name="CARET_COLOR" value="#81C784" />
+    <option name="SELECTION_BACKGROUND" value="#313131" />
+  </colors>
+  <attributes>
+    <option name="DEFAULT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="#81C784" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_STRING">
+      <value>
+        <option name="FOREGROUND" value="#A5D6A7" />
+      </value>
+    </option>
+    <option name="DEFAULT_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="#66BB6A" />
+      </value>
+    </option>
+    <option name="DEFAULT_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#4CAF50" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#A0CFA4" />
+      </value>
+    </option>
+  </attributes>
+</scheme>

--- a/src/main/resources/TrueBlackPremium.theme.json
+++ b/src/main/resources/TrueBlackPremium.theme.json
@@ -1,0 +1,360 @@
+{
+  "name": "True Black Premium",
+  "dark": true,
+  "author": "Ahmed Elshaer",
+  "editorScheme": "/TrueBlackPremium.xml",
+  "colors": {
+    "primary": "#000000",
+    "secondary": "#000000",
+    "activeSelection": "#505050",
+    "inactiveSelection": "#353535",
+    "borderColor": "#1c1c1c",
+    "separatorColor": "#1F1F1F",
+    "accentColor": "#FFD700"
+  },
+  "ui": {
+    "*": {
+      "arc": "6",
+      "background": "primary",
+      "selectionBackground": "activeSelection",
+      "selectionInactiveBackground": "inactiveSelection",
+      "disabledBackground": "primary",
+      "underlineColor": "accentColor",
+      "borderColor": "borderColor",
+      "separatorColor": "separatorColor",
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ActionButton": {
+      "hoverBorderColor": "accentColor",
+      "hoverBackground": "secondary",
+      "pressedBorderColor": "accentColor",
+      "pressedBackground": "secondary"
+    },
+    "Bookmark": {
+    },
+    "BookmarkMnemonicAssigned": {
+      "background": "inactiveSelection",
+      "borderColor": "inactiveSelection"
+    },
+    "BookmarkMnemonicCurrent": {
+      "background": "activeSelection",
+      "borderColor": "activeSelection"
+    },
+    "Borders": {
+      "color": "borderColor",
+      "ContrastBorderColor": "borderColor"
+    },
+    "Button": {
+      "foreground": "#D1D1D1",
+      "startBackground": "secondary",
+      "endBackground": "secondary",
+      "focusedBorderColor": "accentColor",
+      "startBorderColor": "inactiveSelection",
+      "endBorderColor": "inactiveSelection",
+      "default": {
+        "foreground": "#FFFFFF",
+        "startBackground": "accentColor",
+        "endBackground": "accentColor",
+        "startBorderColor": "accentColor",
+        "endBorderColor": "accentColor",
+        "focusColor": "accentColor",
+        "focusedBorderColor": "accentColor"
+      }
+    },
+    "Counter": {
+      "foreground": "#D1D1D1"
+    },
+    "TextField": {
+      "background": "primary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ComboBox": {
+      "nonEditableBackground": "secondary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "borderColor": "borderColor",
+      "ArrowButton": {
+        "background": "secondary",
+        "nonEditableBackground": "secondary"
+      }
+    },
+    "CompletionPopup": {
+      "matchForeground": "#fc5fa3",
+      "selectionBackground": "activeSelection",
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "Component": {
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor",
+      "disabledBorderColor": "borderColor"
+    },
+    "Editor": {
+      "shortcutForeground": "accentColor",
+      "background": "secondary",
+      "SearchField.borderColor": "borderColor",
+      "Tooltip.background": "inactiveSelection",
+      "Tooltip.borderColor": "borderColor",
+      "currentLineHighlight.style": "rounded",
+      "lineHighlight.borderRadius": 6,
+      "caretRow.style": "rounded"
+    },
+    "EditorTabs": {
+      "underlinedTabBackground": "primary",
+      "background": "secondary",
+      "underlineHeight": 2,
+      "tabArc": 6,
+      "underlineColor": "accentColor",
+      "selectedBackground": "activeSelection",
+      "selectedForeground": "accentColor",
+      "hoverBackground": "inactiveSelection"
+    },
+    "Link": {
+      "activeForeground": "accentColor",
+      "hoverForeground": "accentColor",
+      "visitedForeground": "#9F7AEA",
+      "pressedForeground": "accentColor"
+    },
+    "LoadingIndicator": {
+      "color": "#A78BFA",
+      "backgroundColor": "primary"
+    },
+    "Spinner": {
+      "background": "secondary",
+      "foreground": "#A78BFA",
+      "selectionForeground": "#C8A8E9"
+    },
+    "ProcessIndicator": {
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9"
+    },
+    "Notification": {
+      "ToolWindow": {
+        "informativeBackground": "primary",
+        "informativeBorderColor": "#42b827",
+        "informativeForeground": "#D1D1D1",
+        "warningBackground": "primary",
+        "errorBackground": "primary"
+      }
+    },
+    "Plugins": {
+      "hoverBackground": "accentColor",
+      "hoverForeground": "#FFFFFF",
+      "lightSelectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "foreground": "#D1D1D1"
+    },
+    "PasswordField": {
+      "background": "secondary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ProgressBar": {
+      "background": "primary",
+      "foreground": "#A78BFA",
+      "selectionBackground": "#B794F6",
+      "selectionForeground": "#C8A8E9",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "progressColor": "#A78BFA",
+      "trackColor": "inactiveSelection",
+      "passedColor": "#B794F6",
+      "passedEndColor": "#C8A8E9"
+    },
+    "SearchMatch": {
+      "startBackground": "#eeed38",
+      "endBackground": "#eeed38"
+    },
+    "SearchEverywhere": {
+      "Tab": {
+        "selectedBackground": "accentColor",
+        "selectedForeground": "#FFFFFF"
+      }
+    },
+    "SidePanel": {
+      "background": "secondary"
+    },
+    "StatusBar": {
+      "hoverBackground": "secondary"
+    },
+    "Table": {
+      "hoverBackground": "inactiveSelection",
+      "lightSelectionBackground": "accentColor",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverForeground": "#D1D1D1",
+      "gridColor": "borderColor"
+    },
+    "TableHeader": {
+      "bottomSeparatorColor": "separatorColor",
+      "borderColor": "borderColor"
+    },
+    "ToggleButton": {
+      "onBackground": "#D1D1D1"
+    },
+    "ToolWindow": {
+      "Button": {
+        "selectedBackground": "secondary"
+      },
+      "Header": {
+        "background": "primary",
+        "inactiveBackground": "secondary"
+      }
+    },
+    "Tree": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "foreground": "#D1D1D1",
+      "rowHeight": 22,
+      "selectionForeground": "#FFFFFF"
+    },
+    "VersionControl": {
+      "Log": {
+        "Commit": {
+          "currentBranchBackground": "accentColor",
+          "hoveredBackground": "inactiveSelection"
+        }
+      }
+    },
+    "WelcomeScreen": {
+      "SidePanel": {
+        "background": "secondary"
+      },
+      "Projects": {
+        "background": "inactiveSelection",
+        "actions": {
+          "background": "inactiveSelection"
+        }
+      }
+    },
+    "FileColor": {
+      "Yellow": "121212",
+      "Green": "121212",
+      "Blue": "121212",
+      "Violet": "121212",
+      "Orange": "121212",
+      "Rose": "121212"
+    },
+    "ProjectView": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "selectionForeground": "#FFFFFF"
+    },
+    "FileColors": {
+      "enabledForTabs": false,
+      "enabledForProjectView": false
+    },
+    "Scope": {
+      "background": "primary"
+    },
+    "Popup": {
+      "background": "primary",
+      "Header.activeBackground": "accentColor",
+      "Header.inactiveBackground": "inactiveSelection",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "Advertiser": {
+        "background": "inactiveSelection",
+        "borderColor": "borderColor"
+      }
+    },
+    "Breadcrumbs": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "hoverBackground": "inactiveSelection",
+      "borderColor": "borderColor",
+      "selectionForeground": "#FFFFFF"
+    },
+    "Menu": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "selectionBackground": "activeSelection"
+    },
+    "CheckBox": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "RadioButton": {
+      "background": "primary", 
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "FormattedTextField": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1"
+    },
+    "TextArea": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TextPane": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TaskProgressBar": {
+      "background": "primary",
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "passedColor": "#B794F6",
+      "trackColor": "inactiveSelection"
+    },
+    "InplaceRefactoringPopup": {
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "AsyncProcessIcon": {
+      "color": "#A78BFA"
+    },
+    "InternalFrameTitlePane": {
+      "background": "secondary",
+      "inactiveBackground": "primary"
+    },
+    "ScrollBar": {
+      "background": "primary",
+      "Thumb": {
+        "background": "inactiveSelection",
+        "hoverBackground": "accentColor",
+        "pressedBackground": "accentColor"
+      },
+      "track": "primary"
+    },
+    "Slider": {
+      "background": "primary",
+      "foreground": "accentColor",
+      "track": "inactiveSelection",
+      "thumb": "accentColor",
+      "focus": "accentColor"
+    },
+    "TabbedPane": {
+      "background": "secondary",
+      "selectedBackground": "accentColor",
+      "selectedForeground": "#FFFFFF",
+      "hoverColor": "inactiveSelection",
+      "focusColor": "accentColor",
+      "underlineColor": "accentColor",
+      "foreground": "#D1D1D1",
+      "hoverForeground": "#D1D1D1"
+    },
+    "List": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverBackground": "inactiveSelection"
+    }
+  }
+}

--- a/src/main/resources/TrueBlackPremium.xml
+++ b/src/main/resources/TrueBlackPremium.xml
@@ -1,0 +1,42 @@
+<scheme name="True Black Premium" version="142" parent_scheme="True Black">
+  <metaInfo>
+    <property name="created">2023-07-17T14:11:44</property>
+    <property name="ide">Idea</property>
+    <property name="ideVersion">231.9161.38</property>
+    <property name="modified">2023-07-17T14:11:44</property>
+    <property name="originalScheme">True Black</property>
+  </metaInfo>
+  <colors>
+    <option name="LINE_NUMBER_ON_CARET_ROW_COLOR" value="#FFD700" />
+    <option name="CARET_COLOR" value="#FFD700" />
+    <option name="SELECTION_BACKGROUND" value="#313131" />
+  </colors>
+  <attributes>
+    <option name="DEFAULT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="#FFD700" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_STRING">
+      <value>
+        <option name="FOREGROUND" value="#FFF176" />
+      </value>
+    </option>
+    <option name="DEFAULT_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="#FFC107" />
+      </value>
+    </option>
+    <option name="DEFAULT_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#BDB76B" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#F0E68C" />
+      </value>
+    </option>
+  </attributes>
+</scheme>

--- a/src/main/resources/TrueBlackRuby.theme.json
+++ b/src/main/resources/TrueBlackRuby.theme.json
@@ -1,0 +1,360 @@
+{
+  "name": "True Black Ruby",
+  "dark": true,
+  "author": "Ahmed Elshaer",
+  "editorScheme": "/TrueBlackRuby.xml",
+  "colors": {
+    "primary": "#000000",
+    "secondary": "#000000",
+    "activeSelection": "#505050",
+    "inactiveSelection": "#353535",
+    "borderColor": "#1c1c1c",
+    "separatorColor": "#1F1F1F",
+    "accentColor": "#E53935"
+  },
+  "ui": {
+    "*": {
+      "arc": "6",
+      "background": "primary",
+      "selectionBackground": "activeSelection",
+      "selectionInactiveBackground": "inactiveSelection",
+      "disabledBackground": "primary",
+      "underlineColor": "accentColor",
+      "borderColor": "borderColor",
+      "separatorColor": "separatorColor",
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ActionButton": {
+      "hoverBorderColor": "accentColor",
+      "hoverBackground": "secondary",
+      "pressedBorderColor": "accentColor",
+      "pressedBackground": "secondary"
+    },
+    "Bookmark": {
+    },
+    "BookmarkMnemonicAssigned": {
+      "background": "inactiveSelection",
+      "borderColor": "inactiveSelection"
+    },
+    "BookmarkMnemonicCurrent": {
+      "background": "activeSelection",
+      "borderColor": "activeSelection"
+    },
+    "Borders": {
+      "color": "borderColor",
+      "ContrastBorderColor": "borderColor"
+    },
+    "Button": {
+      "foreground": "#D1D1D1",
+      "startBackground": "secondary",
+      "endBackground": "secondary",
+      "focusedBorderColor": "accentColor",
+      "startBorderColor": "inactiveSelection",
+      "endBorderColor": "inactiveSelection",
+      "default": {
+        "foreground": "#FFFFFF",
+        "startBackground": "accentColor",
+        "endBackground": "accentColor",
+        "startBorderColor": "accentColor",
+        "endBorderColor": "accentColor",
+        "focusColor": "accentColor",
+        "focusedBorderColor": "accentColor"
+      }
+    },
+    "Counter": {
+      "foreground": "#D1D1D1"
+    },
+    "TextField": {
+      "background": "primary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ComboBox": {
+      "nonEditableBackground": "secondary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "borderColor": "borderColor",
+      "ArrowButton": {
+        "background": "secondary",
+        "nonEditableBackground": "secondary"
+      }
+    },
+    "CompletionPopup": {
+      "matchForeground": "#fc5fa3",
+      "selectionBackground": "activeSelection",
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "Component": {
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor",
+      "disabledBorderColor": "borderColor"
+    },
+    "Editor": {
+      "shortcutForeground": "accentColor",
+      "background": "secondary",
+      "SearchField.borderColor": "borderColor",
+      "Tooltip.background": "inactiveSelection",
+      "Tooltip.borderColor": "borderColor",
+      "currentLineHighlight.style": "rounded",
+      "lineHighlight.borderRadius": 6,
+      "caretRow.style": "rounded"
+    },
+    "EditorTabs": {
+      "underlinedTabBackground": "primary",
+      "background": "secondary",
+      "underlineHeight": 2,
+      "tabArc": 6,
+      "underlineColor": "accentColor",
+      "selectedBackground": "activeSelection",
+      "selectedForeground": "accentColor",
+      "hoverBackground": "inactiveSelection"
+    },
+    "Link": {
+      "activeForeground": "accentColor",
+      "hoverForeground": "accentColor",
+      "visitedForeground": "#9F7AEA",
+      "pressedForeground": "accentColor"
+    },
+    "LoadingIndicator": {
+      "color": "#A78BFA",
+      "backgroundColor": "primary"
+    },
+    "Spinner": {
+      "background": "secondary",
+      "foreground": "#A78BFA",
+      "selectionForeground": "#C8A8E9"
+    },
+    "ProcessIndicator": {
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9"
+    },
+    "Notification": {
+      "ToolWindow": {
+        "informativeBackground": "primary",
+        "informativeBorderColor": "#42b827",
+        "informativeForeground": "#D1D1D1",
+        "warningBackground": "primary",
+        "errorBackground": "primary"
+      }
+    },
+    "Plugins": {
+      "hoverBackground": "accentColor",
+      "hoverForeground": "#FFFFFF",
+      "lightSelectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "foreground": "#D1D1D1"
+    },
+    "PasswordField": {
+      "background": "secondary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ProgressBar": {
+      "background": "primary",
+      "foreground": "#A78BFA",
+      "selectionBackground": "#B794F6",
+      "selectionForeground": "#C8A8E9",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "progressColor": "#A78BFA",
+      "trackColor": "inactiveSelection",
+      "passedColor": "#B794F6",
+      "passedEndColor": "#C8A8E9"
+    },
+    "SearchMatch": {
+      "startBackground": "#eeed38",
+      "endBackground": "#eeed38"
+    },
+    "SearchEverywhere": {
+      "Tab": {
+        "selectedBackground": "accentColor",
+        "selectedForeground": "#FFFFFF"
+      }
+    },
+    "SidePanel": {
+      "background": "secondary"
+    },
+    "StatusBar": {
+      "hoverBackground": "secondary"
+    },
+    "Table": {
+      "hoverBackground": "inactiveSelection",
+      "lightSelectionBackground": "accentColor",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverForeground": "#D1D1D1",
+      "gridColor": "borderColor"
+    },
+    "TableHeader": {
+      "bottomSeparatorColor": "separatorColor",
+      "borderColor": "borderColor"
+    },
+    "ToggleButton": {
+      "onBackground": "#D1D1D1"
+    },
+    "ToolWindow": {
+      "Button": {
+        "selectedBackground": "secondary"
+      },
+      "Header": {
+        "background": "primary",
+        "inactiveBackground": "secondary"
+      }
+    },
+    "Tree": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "foreground": "#D1D1D1",
+      "rowHeight": 22,
+      "selectionForeground": "#FFFFFF"
+    },
+    "VersionControl": {
+      "Log": {
+        "Commit": {
+          "currentBranchBackground": "accentColor",
+          "hoveredBackground": "inactiveSelection"
+        }
+      }
+    },
+    "WelcomeScreen": {
+      "SidePanel": {
+        "background": "secondary"
+      },
+      "Projects": {
+        "background": "inactiveSelection",
+        "actions": {
+          "background": "inactiveSelection"
+        }
+      }
+    },
+    "FileColor": {
+      "Yellow": "121212",
+      "Green": "121212",
+      "Blue": "121212",
+      "Violet": "121212",
+      "Orange": "121212",
+      "Rose": "121212"
+    },
+    "ProjectView": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "selectionForeground": "#FFFFFF"
+    },
+    "FileColors": {
+      "enabledForTabs": false,
+      "enabledForProjectView": false
+    },
+    "Scope": {
+      "background": "primary"
+    },
+    "Popup": {
+      "background": "primary",
+      "Header.activeBackground": "accentColor",
+      "Header.inactiveBackground": "inactiveSelection",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "Advertiser": {
+        "background": "inactiveSelection",
+        "borderColor": "borderColor"
+      }
+    },
+    "Breadcrumbs": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "hoverBackground": "inactiveSelection",
+      "borderColor": "borderColor",
+      "selectionForeground": "#FFFFFF"
+    },
+    "Menu": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "selectionBackground": "activeSelection"
+    },
+    "CheckBox": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "RadioButton": {
+      "background": "primary", 
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "FormattedTextField": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1"
+    },
+    "TextArea": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TextPane": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TaskProgressBar": {
+      "background": "primary",
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "passedColor": "#B794F6",
+      "trackColor": "inactiveSelection"
+    },
+    "InplaceRefactoringPopup": {
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "AsyncProcessIcon": {
+      "color": "#A78BFA"
+    },
+    "InternalFrameTitlePane": {
+      "background": "secondary",
+      "inactiveBackground": "primary"
+    },
+    "ScrollBar": {
+      "background": "primary",
+      "Thumb": {
+        "background": "inactiveSelection",
+        "hoverBackground": "accentColor",
+        "pressedBackground": "accentColor"
+      },
+      "track": "primary"
+    },
+    "Slider": {
+      "background": "primary",
+      "foreground": "accentColor",
+      "track": "inactiveSelection",
+      "thumb": "accentColor",
+      "focus": "accentColor"
+    },
+    "TabbedPane": {
+      "background": "secondary",
+      "selectedBackground": "accentColor",
+      "selectedForeground": "#FFFFFF",
+      "hoverColor": "inactiveSelection",
+      "focusColor": "accentColor",
+      "underlineColor": "accentColor",
+      "foreground": "#D1D1D1",
+      "hoverForeground": "#D1D1D1"
+    },
+    "List": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverBackground": "inactiveSelection"
+    }
+  }
+}

--- a/src/main/resources/TrueBlackRuby.xml
+++ b/src/main/resources/TrueBlackRuby.xml
@@ -1,0 +1,42 @@
+<scheme name="True Black Ruby" version="142" parent_scheme="True Black">
+  <metaInfo>
+    <property name="created">2023-07-17T14:11:44</property>
+    <property name="ide">Idea</property>
+    <property name="ideVersion">231.9161.38</property>
+    <property name="modified">2023-07-17T14:11:44</property>
+    <property name="originalScheme">True Black</property>
+  </metaInfo>
+  <colors>
+    <option name="LINE_NUMBER_ON_CARET_ROW_COLOR" value="#E53935" />
+    <option name="CARET_COLOR" value="#E53935" />
+    <option name="SELECTION_BACKGROUND" value="#313131" />
+  </colors>
+  <attributes>
+    <option name="DEFAULT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="#E53935" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_STRING">
+      <value>
+        <option name="FOREGROUND" value="#FF6B6B" />
+      </value>
+    </option>
+    <option name="DEFAULT_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="#FF8A80" />
+      </value>
+    </option>
+    <option name="DEFAULT_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#B71C1C" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#EF9A9A" />
+      </value>
+    </option>
+  </attributes>
+</scheme>

--- a/src/main/resources/TrueBlackSeasonal.theme.json
+++ b/src/main/resources/TrueBlackSeasonal.theme.json
@@ -1,0 +1,360 @@
+{
+  "name": "True Black Seasonal",
+  "dark": true,
+  "author": "Ahmed Elshaer",
+  "editorScheme": "/TrueBlackSeasonal.xml",
+  "colors": {
+    "primary": "#000000",
+    "secondary": "#000000",
+    "activeSelection": "#505050",
+    "inactiveSelection": "#353535",
+    "borderColor": "#1c1c1c",
+    "separatorColor": "#1F1F1F",
+    "accentColor": "#FFB74D"
+  },
+  "ui": {
+    "*": {
+      "arc": "6",
+      "background": "primary",
+      "selectionBackground": "activeSelection",
+      "selectionInactiveBackground": "inactiveSelection",
+      "disabledBackground": "primary",
+      "underlineColor": "accentColor",
+      "borderColor": "borderColor",
+      "separatorColor": "separatorColor",
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ActionButton": {
+      "hoverBorderColor": "accentColor",
+      "hoverBackground": "secondary",
+      "pressedBorderColor": "accentColor",
+      "pressedBackground": "secondary"
+    },
+    "Bookmark": {
+    },
+    "BookmarkMnemonicAssigned": {
+      "background": "inactiveSelection",
+      "borderColor": "inactiveSelection"
+    },
+    "BookmarkMnemonicCurrent": {
+      "background": "activeSelection",
+      "borderColor": "activeSelection"
+    },
+    "Borders": {
+      "color": "borderColor",
+      "ContrastBorderColor": "borderColor"
+    },
+    "Button": {
+      "foreground": "#D1D1D1",
+      "startBackground": "secondary",
+      "endBackground": "secondary",
+      "focusedBorderColor": "accentColor",
+      "startBorderColor": "inactiveSelection",
+      "endBorderColor": "inactiveSelection",
+      "default": {
+        "foreground": "#FFFFFF",
+        "startBackground": "accentColor",
+        "endBackground": "accentColor",
+        "startBorderColor": "accentColor",
+        "endBorderColor": "accentColor",
+        "focusColor": "accentColor",
+        "focusedBorderColor": "accentColor"
+      }
+    },
+    "Counter": {
+      "foreground": "#D1D1D1"
+    },
+    "TextField": {
+      "background": "primary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ComboBox": {
+      "nonEditableBackground": "secondary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "borderColor": "borderColor",
+      "ArrowButton": {
+        "background": "secondary",
+        "nonEditableBackground": "secondary"
+      }
+    },
+    "CompletionPopup": {
+      "matchForeground": "#fc5fa3",
+      "selectionBackground": "activeSelection",
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "Component": {
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor",
+      "disabledBorderColor": "borderColor"
+    },
+    "Editor": {
+      "shortcutForeground": "accentColor",
+      "background": "secondary",
+      "SearchField.borderColor": "borderColor",
+      "Tooltip.background": "inactiveSelection",
+      "Tooltip.borderColor": "borderColor",
+      "currentLineHighlight.style": "rounded",
+      "lineHighlight.borderRadius": 6,
+      "caretRow.style": "rounded"
+    },
+    "EditorTabs": {
+      "underlinedTabBackground": "primary",
+      "background": "secondary",
+      "underlineHeight": 2,
+      "tabArc": 6,
+      "underlineColor": "accentColor",
+      "selectedBackground": "activeSelection",
+      "selectedForeground": "accentColor",
+      "hoverBackground": "inactiveSelection"
+    },
+    "Link": {
+      "activeForeground": "accentColor",
+      "hoverForeground": "accentColor",
+      "visitedForeground": "#9F7AEA",
+      "pressedForeground": "accentColor"
+    },
+    "LoadingIndicator": {
+      "color": "#A78BFA",
+      "backgroundColor": "primary"
+    },
+    "Spinner": {
+      "background": "secondary",
+      "foreground": "#A78BFA",
+      "selectionForeground": "#C8A8E9"
+    },
+    "ProcessIndicator": {
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9"
+    },
+    "Notification": {
+      "ToolWindow": {
+        "informativeBackground": "primary",
+        "informativeBorderColor": "#42b827",
+        "informativeForeground": "#D1D1D1",
+        "warningBackground": "primary",
+        "errorBackground": "primary"
+      }
+    },
+    "Plugins": {
+      "hoverBackground": "accentColor",
+      "hoverForeground": "#FFFFFF",
+      "lightSelectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "foreground": "#D1D1D1"
+    },
+    "PasswordField": {
+      "background": "secondary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ProgressBar": {
+      "background": "primary",
+      "foreground": "#A78BFA",
+      "selectionBackground": "#B794F6",
+      "selectionForeground": "#C8A8E9",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "progressColor": "#A78BFA",
+      "trackColor": "inactiveSelection",
+      "passedColor": "#B794F6",
+      "passedEndColor": "#C8A8E9"
+    },
+    "SearchMatch": {
+      "startBackground": "#eeed38",
+      "endBackground": "#eeed38"
+    },
+    "SearchEverywhere": {
+      "Tab": {
+        "selectedBackground": "accentColor",
+        "selectedForeground": "#FFFFFF"
+      }
+    },
+    "SidePanel": {
+      "background": "secondary"
+    },
+    "StatusBar": {
+      "hoverBackground": "secondary"
+    },
+    "Table": {
+      "hoverBackground": "inactiveSelection",
+      "lightSelectionBackground": "accentColor",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverForeground": "#D1D1D1",
+      "gridColor": "borderColor"
+    },
+    "TableHeader": {
+      "bottomSeparatorColor": "separatorColor",
+      "borderColor": "borderColor"
+    },
+    "ToggleButton": {
+      "onBackground": "#D1D1D1"
+    },
+    "ToolWindow": {
+      "Button": {
+        "selectedBackground": "secondary"
+      },
+      "Header": {
+        "background": "primary",
+        "inactiveBackground": "secondary"
+      }
+    },
+    "Tree": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "foreground": "#D1D1D1",
+      "rowHeight": 22,
+      "selectionForeground": "#FFFFFF"
+    },
+    "VersionControl": {
+      "Log": {
+        "Commit": {
+          "currentBranchBackground": "accentColor",
+          "hoveredBackground": "inactiveSelection"
+        }
+      }
+    },
+    "WelcomeScreen": {
+      "SidePanel": {
+        "background": "secondary"
+      },
+      "Projects": {
+        "background": "inactiveSelection",
+        "actions": {
+          "background": "inactiveSelection"
+        }
+      }
+    },
+    "FileColor": {
+      "Yellow": "121212",
+      "Green": "121212",
+      "Blue": "121212",
+      "Violet": "121212",
+      "Orange": "121212",
+      "Rose": "121212"
+    },
+    "ProjectView": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "selectionForeground": "#FFFFFF"
+    },
+    "FileColors": {
+      "enabledForTabs": false,
+      "enabledForProjectView": false
+    },
+    "Scope": {
+      "background": "primary"
+    },
+    "Popup": {
+      "background": "primary",
+      "Header.activeBackground": "accentColor",
+      "Header.inactiveBackground": "inactiveSelection",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "Advertiser": {
+        "background": "inactiveSelection",
+        "borderColor": "borderColor"
+      }
+    },
+    "Breadcrumbs": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "hoverBackground": "inactiveSelection",
+      "borderColor": "borderColor",
+      "selectionForeground": "#FFFFFF"
+    },
+    "Menu": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "selectionBackground": "activeSelection"
+    },
+    "CheckBox": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "RadioButton": {
+      "background": "primary", 
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "FormattedTextField": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1"
+    },
+    "TextArea": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TextPane": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TaskProgressBar": {
+      "background": "primary",
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "passedColor": "#B794F6",
+      "trackColor": "inactiveSelection"
+    },
+    "InplaceRefactoringPopup": {
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "AsyncProcessIcon": {
+      "color": "#A78BFA"
+    },
+    "InternalFrameTitlePane": {
+      "background": "secondary",
+      "inactiveBackground": "primary"
+    },
+    "ScrollBar": {
+      "background": "primary",
+      "Thumb": {
+        "background": "inactiveSelection",
+        "hoverBackground": "accentColor",
+        "pressedBackground": "accentColor"
+      },
+      "track": "primary"
+    },
+    "Slider": {
+      "background": "primary",
+      "foreground": "accentColor",
+      "track": "inactiveSelection",
+      "thumb": "accentColor",
+      "focus": "accentColor"
+    },
+    "TabbedPane": {
+      "background": "secondary",
+      "selectedBackground": "accentColor",
+      "selectedForeground": "#FFFFFF",
+      "hoverColor": "inactiveSelection",
+      "focusColor": "accentColor",
+      "underlineColor": "accentColor",
+      "foreground": "#D1D1D1",
+      "hoverForeground": "#D1D1D1"
+    },
+    "List": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverBackground": "inactiveSelection"
+    }
+  }
+}

--- a/src/main/resources/TrueBlackSeasonal.xml
+++ b/src/main/resources/TrueBlackSeasonal.xml
@@ -1,0 +1,42 @@
+<scheme name="True Black Seasonal" version="142" parent_scheme="True Black">
+  <metaInfo>
+    <property name="created">2023-07-17T14:11:44</property>
+    <property name="ide">Idea</property>
+    <property name="ideVersion">231.9161.38</property>
+    <property name="modified">2023-07-17T14:11:44</property>
+    <property name="originalScheme">True Black</property>
+  </metaInfo>
+  <colors>
+    <option name="LINE_NUMBER_ON_CARET_ROW_COLOR" value="#FFB74D" />
+    <option name="CARET_COLOR" value="#FFB74D" />
+    <option name="SELECTION_BACKGROUND" value="#313131" />
+  </colors>
+  <attributes>
+    <option name="DEFAULT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="#FFB74D" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_STRING">
+      <value>
+        <option name="FOREGROUND" value="#81C784" />
+      </value>
+    </option>
+    <option name="DEFAULT_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="#4FC3F7" />
+      </value>
+    </option>
+    <option name="DEFAULT_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#E57373" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#A1887F" />
+      </value>
+    </option>
+  </attributes>
+</scheme>

--- a/src/main/resources/TrueBlackSpace.theme.json
+++ b/src/main/resources/TrueBlackSpace.theme.json
@@ -1,0 +1,360 @@
+{
+  "name": "True Black Space",
+  "dark": true,
+  "author": "Ahmed Elshaer",
+  "editorScheme": "/TrueBlackSpace.xml",
+  "colors": {
+    "primary": "#000000",
+    "secondary": "#000000",
+    "activeSelection": "#505050",
+    "inactiveSelection": "#353535",
+    "borderColor": "#1c1c1c",
+    "separatorColor": "#1F1F1F",
+    "accentColor": "#90CAF9"
+  },
+  "ui": {
+    "*": {
+      "arc": "6",
+      "background": "primary",
+      "selectionBackground": "activeSelection",
+      "selectionInactiveBackground": "inactiveSelection",
+      "disabledBackground": "primary",
+      "underlineColor": "accentColor",
+      "borderColor": "borderColor",
+      "separatorColor": "separatorColor",
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ActionButton": {
+      "hoverBorderColor": "accentColor",
+      "hoverBackground": "secondary",
+      "pressedBorderColor": "accentColor",
+      "pressedBackground": "secondary"
+    },
+    "Bookmark": {
+    },
+    "BookmarkMnemonicAssigned": {
+      "background": "inactiveSelection",
+      "borderColor": "inactiveSelection"
+    },
+    "BookmarkMnemonicCurrent": {
+      "background": "activeSelection",
+      "borderColor": "activeSelection"
+    },
+    "Borders": {
+      "color": "borderColor",
+      "ContrastBorderColor": "borderColor"
+    },
+    "Button": {
+      "foreground": "#D1D1D1",
+      "startBackground": "secondary",
+      "endBackground": "secondary",
+      "focusedBorderColor": "accentColor",
+      "startBorderColor": "inactiveSelection",
+      "endBorderColor": "inactiveSelection",
+      "default": {
+        "foreground": "#FFFFFF",
+        "startBackground": "accentColor",
+        "endBackground": "accentColor",
+        "startBorderColor": "accentColor",
+        "endBorderColor": "accentColor",
+        "focusColor": "accentColor",
+        "focusedBorderColor": "accentColor"
+      }
+    },
+    "Counter": {
+      "foreground": "#D1D1D1"
+    },
+    "TextField": {
+      "background": "primary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ComboBox": {
+      "nonEditableBackground": "secondary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "borderColor": "borderColor",
+      "ArrowButton": {
+        "background": "secondary",
+        "nonEditableBackground": "secondary"
+      }
+    },
+    "CompletionPopup": {
+      "matchForeground": "#fc5fa3",
+      "selectionBackground": "activeSelection",
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "Component": {
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor",
+      "disabledBorderColor": "borderColor"
+    },
+    "Editor": {
+      "shortcutForeground": "accentColor",
+      "background": "secondary",
+      "SearchField.borderColor": "borderColor",
+      "Tooltip.background": "inactiveSelection",
+      "Tooltip.borderColor": "borderColor",
+      "currentLineHighlight.style": "rounded",
+      "lineHighlight.borderRadius": 6,
+      "caretRow.style": "rounded"
+    },
+    "EditorTabs": {
+      "underlinedTabBackground": "primary",
+      "background": "secondary",
+      "underlineHeight": 2,
+      "tabArc": 6,
+      "underlineColor": "accentColor",
+      "selectedBackground": "activeSelection",
+      "selectedForeground": "accentColor",
+      "hoverBackground": "inactiveSelection"
+    },
+    "Link": {
+      "activeForeground": "accentColor",
+      "hoverForeground": "accentColor",
+      "visitedForeground": "#9F7AEA",
+      "pressedForeground": "accentColor"
+    },
+    "LoadingIndicator": {
+      "color": "#A78BFA",
+      "backgroundColor": "primary"
+    },
+    "Spinner": {
+      "background": "secondary",
+      "foreground": "#A78BFA",
+      "selectionForeground": "#C8A8E9"
+    },
+    "ProcessIndicator": {
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9"
+    },
+    "Notification": {
+      "ToolWindow": {
+        "informativeBackground": "primary",
+        "informativeBorderColor": "#42b827",
+        "informativeForeground": "#D1D1D1",
+        "warningBackground": "primary",
+        "errorBackground": "primary"
+      }
+    },
+    "Plugins": {
+      "hoverBackground": "accentColor",
+      "hoverForeground": "#FFFFFF",
+      "lightSelectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "foreground": "#D1D1D1"
+    },
+    "PasswordField": {
+      "background": "secondary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ProgressBar": {
+      "background": "primary",
+      "foreground": "#A78BFA",
+      "selectionBackground": "#B794F6",
+      "selectionForeground": "#C8A8E9",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "progressColor": "#A78BFA",
+      "trackColor": "inactiveSelection",
+      "passedColor": "#B794F6",
+      "passedEndColor": "#C8A8E9"
+    },
+    "SearchMatch": {
+      "startBackground": "#eeed38",
+      "endBackground": "#eeed38"
+    },
+    "SearchEverywhere": {
+      "Tab": {
+        "selectedBackground": "accentColor",
+        "selectedForeground": "#FFFFFF"
+      }
+    },
+    "SidePanel": {
+      "background": "secondary"
+    },
+    "StatusBar": {
+      "hoverBackground": "secondary"
+    },
+    "Table": {
+      "hoverBackground": "inactiveSelection",
+      "lightSelectionBackground": "accentColor",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverForeground": "#D1D1D1",
+      "gridColor": "borderColor"
+    },
+    "TableHeader": {
+      "bottomSeparatorColor": "separatorColor",
+      "borderColor": "borderColor"
+    },
+    "ToggleButton": {
+      "onBackground": "#D1D1D1"
+    },
+    "ToolWindow": {
+      "Button": {
+        "selectedBackground": "secondary"
+      },
+      "Header": {
+        "background": "primary",
+        "inactiveBackground": "secondary"
+      }
+    },
+    "Tree": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "foreground": "#D1D1D1",
+      "rowHeight": 22,
+      "selectionForeground": "#FFFFFF"
+    },
+    "VersionControl": {
+      "Log": {
+        "Commit": {
+          "currentBranchBackground": "accentColor",
+          "hoveredBackground": "inactiveSelection"
+        }
+      }
+    },
+    "WelcomeScreen": {
+      "SidePanel": {
+        "background": "secondary"
+      },
+      "Projects": {
+        "background": "inactiveSelection",
+        "actions": {
+          "background": "inactiveSelection"
+        }
+      }
+    },
+    "FileColor": {
+      "Yellow": "121212",
+      "Green": "121212",
+      "Blue": "121212",
+      "Violet": "121212",
+      "Orange": "121212",
+      "Rose": "121212"
+    },
+    "ProjectView": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "selectionForeground": "#FFFFFF"
+    },
+    "FileColors": {
+      "enabledForTabs": false,
+      "enabledForProjectView": false
+    },
+    "Scope": {
+      "background": "primary"
+    },
+    "Popup": {
+      "background": "primary",
+      "Header.activeBackground": "accentColor",
+      "Header.inactiveBackground": "inactiveSelection",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "Advertiser": {
+        "background": "inactiveSelection",
+        "borderColor": "borderColor"
+      }
+    },
+    "Breadcrumbs": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "hoverBackground": "inactiveSelection",
+      "borderColor": "borderColor",
+      "selectionForeground": "#FFFFFF"
+    },
+    "Menu": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "selectionBackground": "activeSelection"
+    },
+    "CheckBox": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "RadioButton": {
+      "background": "primary", 
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "FormattedTextField": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1"
+    },
+    "TextArea": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TextPane": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TaskProgressBar": {
+      "background": "primary",
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "passedColor": "#B794F6",
+      "trackColor": "inactiveSelection"
+    },
+    "InplaceRefactoringPopup": {
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "AsyncProcessIcon": {
+      "color": "#A78BFA"
+    },
+    "InternalFrameTitlePane": {
+      "background": "secondary",
+      "inactiveBackground": "primary"
+    },
+    "ScrollBar": {
+      "background": "primary",
+      "Thumb": {
+        "background": "inactiveSelection",
+        "hoverBackground": "accentColor",
+        "pressedBackground": "accentColor"
+      },
+      "track": "primary"
+    },
+    "Slider": {
+      "background": "primary",
+      "foreground": "accentColor",
+      "track": "inactiveSelection",
+      "thumb": "accentColor",
+      "focus": "accentColor"
+    },
+    "TabbedPane": {
+      "background": "secondary",
+      "selectedBackground": "accentColor",
+      "selectedForeground": "#FFFFFF",
+      "hoverColor": "inactiveSelection",
+      "focusColor": "accentColor",
+      "underlineColor": "accentColor",
+      "foreground": "#D1D1D1",
+      "hoverForeground": "#D1D1D1"
+    },
+    "List": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverBackground": "inactiveSelection"
+    }
+  }
+}

--- a/src/main/resources/TrueBlackSpace.xml
+++ b/src/main/resources/TrueBlackSpace.xml
@@ -1,0 +1,42 @@
+<scheme name="True Black Space" version="142" parent_scheme="True Black">
+  <metaInfo>
+    <property name="created">2023-07-17T14:11:44</property>
+    <property name="ide">Idea</property>
+    <property name="ideVersion">231.9161.38</property>
+    <property name="modified">2023-07-17T14:11:44</property>
+    <property name="originalScheme">True Black</property>
+  </metaInfo>
+  <colors>
+    <option name="LINE_NUMBER_ON_CARET_ROW_COLOR" value="#90CAF9" />
+    <option name="CARET_COLOR" value="#90CAF9" />
+    <option name="SELECTION_BACKGROUND" value="#313131" />
+  </colors>
+  <attributes>
+    <option name="DEFAULT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="#90CAF9" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_STRING">
+      <value>
+        <option name="FOREGROUND" value="#AAB6FE" />
+      </value>
+    </option>
+    <option name="DEFAULT_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="#CE93D8" />
+      </value>
+    </option>
+    <option name="DEFAULT_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#B0BEC5" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#90A4AE" />
+      </value>
+    </option>
+  </attributes>
+</scheme>

--- a/src/main/resources/TrueBlackWarm.theme.json
+++ b/src/main/resources/TrueBlackWarm.theme.json
@@ -1,0 +1,360 @@
+{
+  "name": "True Black Warm",
+  "dark": true,
+  "author": "Ahmed Elshaer",
+  "editorScheme": "/TrueBlackWarm.xml",
+  "colors": {
+    "primary": "#000000",
+    "secondary": "#000000",
+    "activeSelection": "#505050",
+    "inactiveSelection": "#353535",
+    "borderColor": "#1c1c1c",
+    "separatorColor": "#1F1F1F",
+    "accentColor": "#FF8A65"
+  },
+  "ui": {
+    "*": {
+      "arc": "6",
+      "background": "primary",
+      "selectionBackground": "activeSelection",
+      "selectionInactiveBackground": "inactiveSelection",
+      "disabledBackground": "primary",
+      "underlineColor": "accentColor",
+      "borderColor": "borderColor",
+      "separatorColor": "separatorColor",
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ActionButton": {
+      "hoverBorderColor": "accentColor",
+      "hoverBackground": "secondary",
+      "pressedBorderColor": "accentColor",
+      "pressedBackground": "secondary"
+    },
+    "Bookmark": {
+    },
+    "BookmarkMnemonicAssigned": {
+      "background": "inactiveSelection",
+      "borderColor": "inactiveSelection"
+    },
+    "BookmarkMnemonicCurrent": {
+      "background": "activeSelection",
+      "borderColor": "activeSelection"
+    },
+    "Borders": {
+      "color": "borderColor",
+      "ContrastBorderColor": "borderColor"
+    },
+    "Button": {
+      "foreground": "#D1D1D1",
+      "startBackground": "secondary",
+      "endBackground": "secondary",
+      "focusedBorderColor": "accentColor",
+      "startBorderColor": "inactiveSelection",
+      "endBorderColor": "inactiveSelection",
+      "default": {
+        "foreground": "#FFFFFF",
+        "startBackground": "accentColor",
+        "endBackground": "accentColor",
+        "startBorderColor": "accentColor",
+        "endBorderColor": "accentColor",
+        "focusColor": "accentColor",
+        "focusedBorderColor": "accentColor"
+      }
+    },
+    "Counter": {
+      "foreground": "#D1D1D1"
+    },
+    "TextField": {
+      "background": "primary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ComboBox": {
+      "nonEditableBackground": "secondary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "borderColor": "borderColor",
+      "ArrowButton": {
+        "background": "secondary",
+        "nonEditableBackground": "secondary"
+      }
+    },
+    "CompletionPopup": {
+      "matchForeground": "#fc5fa3",
+      "selectionBackground": "activeSelection",
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "Component": {
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor",
+      "disabledBorderColor": "borderColor"
+    },
+    "Editor": {
+      "shortcutForeground": "accentColor",
+      "background": "secondary",
+      "SearchField.borderColor": "borderColor",
+      "Tooltip.background": "inactiveSelection",
+      "Tooltip.borderColor": "borderColor",
+      "currentLineHighlight.style": "rounded",
+      "lineHighlight.borderRadius": 6,
+      "caretRow.style": "rounded"
+    },
+    "EditorTabs": {
+      "underlinedTabBackground": "primary",
+      "background": "secondary",
+      "underlineHeight": 2,
+      "tabArc": 6,
+      "underlineColor": "accentColor",
+      "selectedBackground": "activeSelection",
+      "selectedForeground": "accentColor",
+      "hoverBackground": "inactiveSelection"
+    },
+    "Link": {
+      "activeForeground": "accentColor",
+      "hoverForeground": "accentColor",
+      "visitedForeground": "#9F7AEA",
+      "pressedForeground": "accentColor"
+    },
+    "LoadingIndicator": {
+      "color": "#A78BFA",
+      "backgroundColor": "primary"
+    },
+    "Spinner": {
+      "background": "secondary",
+      "foreground": "#A78BFA",
+      "selectionForeground": "#C8A8E9"
+    },
+    "ProcessIndicator": {
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9"
+    },
+    "Notification": {
+      "ToolWindow": {
+        "informativeBackground": "primary",
+        "informativeBorderColor": "#42b827",
+        "informativeForeground": "#D1D1D1",
+        "warningBackground": "primary",
+        "errorBackground": "primary"
+      }
+    },
+    "Plugins": {
+      "hoverBackground": "accentColor",
+      "hoverForeground": "#FFFFFF",
+      "lightSelectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "foreground": "#D1D1D1"
+    },
+    "PasswordField": {
+      "background": "secondary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ProgressBar": {
+      "background": "primary",
+      "foreground": "#A78BFA",
+      "selectionBackground": "#B794F6",
+      "selectionForeground": "#C8A8E9",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "progressColor": "#A78BFA",
+      "trackColor": "inactiveSelection",
+      "passedColor": "#B794F6",
+      "passedEndColor": "#C8A8E9"
+    },
+    "SearchMatch": {
+      "startBackground": "#eeed38",
+      "endBackground": "#eeed38"
+    },
+    "SearchEverywhere": {
+      "Tab": {
+        "selectedBackground": "accentColor",
+        "selectedForeground": "#FFFFFF"
+      }
+    },
+    "SidePanel": {
+      "background": "secondary"
+    },
+    "StatusBar": {
+      "hoverBackground": "secondary"
+    },
+    "Table": {
+      "hoverBackground": "inactiveSelection",
+      "lightSelectionBackground": "accentColor",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverForeground": "#D1D1D1",
+      "gridColor": "borderColor"
+    },
+    "TableHeader": {
+      "bottomSeparatorColor": "separatorColor",
+      "borderColor": "borderColor"
+    },
+    "ToggleButton": {
+      "onBackground": "#D1D1D1"
+    },
+    "ToolWindow": {
+      "Button": {
+        "selectedBackground": "secondary"
+      },
+      "Header": {
+        "background": "primary",
+        "inactiveBackground": "secondary"
+      }
+    },
+    "Tree": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "foreground": "#D1D1D1",
+      "rowHeight": 22,
+      "selectionForeground": "#FFFFFF"
+    },
+    "VersionControl": {
+      "Log": {
+        "Commit": {
+          "currentBranchBackground": "accentColor",
+          "hoveredBackground": "inactiveSelection"
+        }
+      }
+    },
+    "WelcomeScreen": {
+      "SidePanel": {
+        "background": "secondary"
+      },
+      "Projects": {
+        "background": "inactiveSelection",
+        "actions": {
+          "background": "inactiveSelection"
+        }
+      }
+    },
+    "FileColor": {
+      "Yellow": "121212",
+      "Green": "121212",
+      "Blue": "121212",
+      "Violet": "121212",
+      "Orange": "121212",
+      "Rose": "121212"
+    },
+    "ProjectView": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "selectionForeground": "#FFFFFF"
+    },
+    "FileColors": {
+      "enabledForTabs": false,
+      "enabledForProjectView": false
+    },
+    "Scope": {
+      "background": "primary"
+    },
+    "Popup": {
+      "background": "primary",
+      "Header.activeBackground": "accentColor",
+      "Header.inactiveBackground": "inactiveSelection",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "Advertiser": {
+        "background": "inactiveSelection",
+        "borderColor": "borderColor"
+      }
+    },
+    "Breadcrumbs": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "hoverBackground": "inactiveSelection",
+      "borderColor": "borderColor",
+      "selectionForeground": "#FFFFFF"
+    },
+    "Menu": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "selectionBackground": "activeSelection"
+    },
+    "CheckBox": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "RadioButton": {
+      "background": "primary", 
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "FormattedTextField": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1"
+    },
+    "TextArea": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TextPane": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TaskProgressBar": {
+      "background": "primary",
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "passedColor": "#B794F6",
+      "trackColor": "inactiveSelection"
+    },
+    "InplaceRefactoringPopup": {
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "AsyncProcessIcon": {
+      "color": "#A78BFA"
+    },
+    "InternalFrameTitlePane": {
+      "background": "secondary",
+      "inactiveBackground": "primary"
+    },
+    "ScrollBar": {
+      "background": "primary",
+      "Thumb": {
+        "background": "inactiveSelection",
+        "hoverBackground": "accentColor",
+        "pressedBackground": "accentColor"
+      },
+      "track": "primary"
+    },
+    "Slider": {
+      "background": "primary",
+      "foreground": "accentColor",
+      "track": "inactiveSelection",
+      "thumb": "accentColor",
+      "focus": "accentColor"
+    },
+    "TabbedPane": {
+      "background": "secondary",
+      "selectedBackground": "accentColor",
+      "selectedForeground": "#FFFFFF",
+      "hoverColor": "inactiveSelection",
+      "focusColor": "accentColor",
+      "underlineColor": "accentColor",
+      "foreground": "#D1D1D1",
+      "hoverForeground": "#D1D1D1"
+    },
+    "List": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverBackground": "inactiveSelection"
+    }
+  }
+}

--- a/src/main/resources/TrueBlackWarm.xml
+++ b/src/main/resources/TrueBlackWarm.xml
@@ -1,0 +1,42 @@
+<scheme name="True Black Warm" version="142" parent_scheme="True Black">
+  <metaInfo>
+    <property name="created">2023-07-17T14:11:44</property>
+    <property name="ide">Idea</property>
+    <property name="ideVersion">231.9161.38</property>
+    <property name="modified">2023-07-17T14:11:44</property>
+    <property name="originalScheme">True Black</property>
+  </metaInfo>
+  <colors>
+    <option name="LINE_NUMBER_ON_CARET_ROW_COLOR" value="#FF8A65" />
+    <option name="CARET_COLOR" value="#FF8A65" />
+    <option name="SELECTION_BACKGROUND" value="#313131" />
+  </colors>
+  <attributes>
+    <option name="DEFAULT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="#FF8A65" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_STRING">
+      <value>
+        <option name="FOREGROUND" value="#FFB78A" />
+      </value>
+    </option>
+    <option name="DEFAULT_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="#FFD180" />
+      </value>
+    </option>
+    <option name="DEFAULT_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#B48A72" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#BD9080" />
+      </value>
+    </option>
+  </attributes>
+</scheme>

--- a/src/main/resources/TrueDarkCool.theme.json
+++ b/src/main/resources/TrueDarkCool.theme.json
@@ -1,0 +1,360 @@
+{
+  "name": "True Dark Cool",
+  "dark": true,
+  "author": "Ahmed Elshaer",
+  "editorScheme": "/TrueDarkCool.xml",
+  "colors": {
+    "primary": "#121212",
+    "secondary": "#121212",
+    "activeSelection": "#2D2D2D",
+    "inactiveSelection": "#1F1F1F",
+    "borderColor": "#1E1E1E",
+    "separatorColor": "#1F1F1F",
+    "accentColor": "#5DB0FF"
+  },
+  "ui": {
+    "*": {
+      "arc": "6",
+      "background": "primary",
+      "selectionBackground": "activeSelection",
+      "selectionInactiveBackground": "inactiveSelection",
+      "disabledBackground": "primary",
+      "underlineColor": "accentColor",
+      "borderColor": "borderColor",
+      "separatorColor": "separatorColor",
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ActionButton": {
+      "hoverBorderColor": "accentColor",
+      "hoverBackground": "secondary",
+      "pressedBorderColor": "accentColor",
+      "pressedBackground": "secondary"
+    },
+    "Bookmark": {
+    },
+    "BookmarkMnemonicAssigned": {
+      "background": "inactiveSelection",
+      "borderColor": "inactiveSelection"
+    },
+    "BookmarkMnemonicCurrent": {
+      "background": "activeSelection",
+      "borderColor": "activeSelection"
+    },
+    "Borders": {
+      "color": "borderColor",
+      "ContrastBorderColor": "borderColor"
+    },
+    "Button": {
+      "foreground": "#D1D1D1",
+      "startBackground": "secondary",
+      "endBackground": "secondary",
+      "focusedBorderColor": "accentColor",
+      "startBorderColor": "inactiveSelection",
+      "endBorderColor": "inactiveSelection",
+      "default": {
+        "foreground": "#FFFFFF",
+        "startBackground": "accentColor",
+        "endBackground": "accentColor",
+        "startBorderColor": "accentColor",
+        "endBorderColor": "accentColor",
+        "focusColor": "accentColor",
+        "focusedBorderColor": "accentColor"
+      }
+    },
+    "Counter": {
+      "foreground": "#D1D1D1"
+    },
+    "TextField": {
+      "background": "primary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ComboBox": {
+      "nonEditableBackground": "secondary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "borderColor": "borderColor",
+      "ArrowButton": {
+        "background": "secondary",
+        "nonEditableBackground": "secondary"
+      }
+    },
+    "CompletionPopup": {
+      "matchForeground": "#fc5fa3",
+      "selectionBackground": "activeSelection",
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "Component": {
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor",
+      "disabledBorderColor": "borderColor"
+    },
+    "Editor": {
+      "shortcutForeground": "accentColor",
+      "background": "secondary",
+      "SearchField.borderColor": "borderColor",
+      "Tooltip.background": "inactiveSelection",
+      "Tooltip.borderColor": "borderColor",
+      "currentLineHighlight.style": "rounded",
+      "lineHighlight.borderRadius": 6,
+      "caretRow.style": "rounded"
+    },
+    "EditorTabs": {
+      "underlinedTabBackground": "primary",
+      "background": "secondary",
+      "underlineHeight": 2,
+      "tabArc": 6,
+      "underlineColor": "accentColor",
+      "selectedBackground": "activeSelection",
+      "selectedForeground": "accentColor",
+      "hoverBackground": "inactiveSelection"
+    },
+    "Link": {
+      "activeForeground": "accentColor",
+      "hoverForeground": "accentColor",
+      "visitedForeground": "#9F7AEA",
+      "pressedForeground": "accentColor"
+    },
+    "LoadingIndicator": {
+      "color": "#A78BFA",
+      "backgroundColor": "primary"
+    },
+    "Spinner": {
+      "background": "secondary",
+      "foreground": "#A78BFA",
+      "selectionForeground": "#C8A8E9"
+    },
+    "ProcessIndicator": {
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9"
+    },
+    "Notification": {
+      "ToolWindow": {
+        "informativeBackground": "primary",
+        "informativeBorderColor": "#42b827",
+        "informativeForeground": "#D1D1D1",
+        "warningBackground": "primary",
+        "errorBackground": "primary"
+      }
+    },
+    "Plugins": {
+      "hoverBackground": "accentColor",
+      "hoverForeground": "#FFFFFF",
+      "lightSelectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "foreground": "#D1D1D1"
+    },
+    "PasswordField": {
+      "background": "secondary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ProgressBar": {
+      "background": "primary",
+      "foreground": "#A78BFA",
+      "selectionBackground": "#B794F6",
+      "selectionForeground": "#C8A8E9",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "progressColor": "#A78BFA",
+      "trackColor": "inactiveSelection",
+      "passedColor": "#B794F6",
+      "passedEndColor": "#C8A8E9"
+    },
+    "SearchMatch": {
+      "startBackground": "#eeed38",
+      "endBackground": "#eeed38"
+    },
+    "SearchEverywhere": {
+      "Tab": {
+        "selectedBackground": "accentColor",
+        "selectedForeground": "#FFFFFF"
+      }
+    },
+    "SidePanel": {
+      "background": "secondary"
+    },
+    "StatusBar": {
+      "hoverBackground": "secondary"
+    },
+    "Table": {
+      "hoverBackground": "inactiveSelection",
+      "lightSelectionBackground": "accentColor",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverForeground": "#D1D1D1",
+      "gridColor": "borderColor"
+    },
+    "TableHeader": {
+      "bottomSeparatorColor": "separatorColor",
+      "borderColor": "borderColor"
+    },
+    "ToggleButton": {
+      "onBackground": "#D1D1D1"
+    },
+    "ToolWindow": {
+      "Button": {
+        "selectedBackground": "secondary"
+      },
+      "Header": {
+        "background": "primary",
+        "inactiveBackground": "secondary"
+      }
+    },
+    "Tree": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "foreground": "#D1D1D1",
+      "rowHeight": 22,
+      "selectionForeground": "#FFFFFF"
+    },
+    "VersionControl": {
+      "Log": {
+        "Commit": {
+          "currentBranchBackground": "accentColor",
+          "hoveredBackground": "inactiveSelection"
+        }
+      }
+    },
+    "WelcomeScreen": {
+      "SidePanel": {
+        "background": "secondary"
+      },
+      "Projects": {
+        "background": "inactiveSelection",
+        "actions": {
+          "background": "inactiveSelection"
+        }
+      }
+    },
+    "FileColor": {
+      "Yellow": "121212",
+      "Green": "121212",
+      "Blue": "121212",
+      "Violet": "121212",
+      "Orange": "121212",
+      "Rose": "121212"
+    },
+    "ProjectView": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "selectionForeground": "#FFFFFF"
+    },
+    "FileColors": {
+      "enabledForTabs": false,
+      "enabledForProjectView": false
+    },
+    "Scope": {
+      "background": "primary"
+    },
+    "Popup": {
+      "background": "primary",
+      "Header.activeBackground": "accentColor",
+      "Header.inactiveBackground": "inactiveSelection",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "Advertiser": {
+        "background": "inactiveSelection",
+        "borderColor": "borderColor"
+      }
+    },
+    "Breadcrumbs": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "hoverBackground": "inactiveSelection",
+      "borderColor": "borderColor",
+      "selectionForeground": "#FFFFFF"
+    },
+    "Menu": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "selectionBackground": "activeSelection"
+    },
+    "CheckBox": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "RadioButton": {
+      "background": "primary", 
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "FormattedTextField": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1"
+    },
+    "TextArea": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TextPane": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TaskProgressBar": {
+      "background": "primary",
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "passedColor": "#B794F6",
+      "trackColor": "inactiveSelection"
+    },
+    "InplaceRefactoringPopup": {
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "AsyncProcessIcon": {
+      "color": "#A78BFA"
+    },
+    "InternalFrameTitlePane": {
+      "background": "secondary",
+      "inactiveBackground": "primary"
+    },
+    "ScrollBar": {
+      "background": "primary",
+      "Thumb": {
+        "background": "inactiveSelection",
+        "hoverBackground": "accentColor",
+        "pressedBackground": "accentColor"
+      },
+      "track": "primary"
+    },
+    "Slider": {
+      "background": "primary",
+      "foreground": "accentColor",
+      "track": "inactiveSelection",
+      "thumb": "accentColor",
+      "focus": "accentColor"
+    },
+    "TabbedPane": {
+      "background": "secondary",
+      "selectedBackground": "accentColor",
+      "selectedForeground": "#FFFFFF",
+      "hoverColor": "inactiveSelection",
+      "focusColor": "accentColor",
+      "underlineColor": "accentColor",
+      "foreground": "#D1D1D1",
+      "hoverForeground": "#D1D1D1"
+    },
+    "List": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverBackground": "inactiveSelection"
+    }
+  }
+}

--- a/src/main/resources/TrueDarkCool.xml
+++ b/src/main/resources/TrueDarkCool.xml
@@ -1,0 +1,42 @@
+<scheme name="True Dark Cool" version="142" parent_scheme="True Dark">
+  <metaInfo>
+    <property name="created">2023-07-18T14:11:44</property>
+    <property name="ide">Idea</property>
+    <property name="ideVersion">231.9161.38</property>
+    <property name="modified">2023-07-18T14:11:44</property>
+    <property name="originalScheme">True Dark</property>
+  </metaInfo>
+  <colors>
+    <option name="LINE_NUMBER_ON_CARET_ROW_COLOR" value="#5DB0FF" />
+    <option name="CARET_COLOR" value="#5DB0FF" />
+    <option name="SELECTION_BACKGROUND" value="#2D2D2D" />
+  </colors>
+  <attributes>
+    <option name="DEFAULT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="#5DB0FF" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_STRING">
+      <value>
+        <option name="FOREGROUND" value="#A1EFFF" />
+      </value>
+    </option>
+    <option name="DEFAULT_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="#2DDBD6" />
+      </value>
+    </option>
+    <option name="DEFAULT_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#6A9955" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#8293A8" />
+      </value>
+    </option>
+  </attributes>
+</scheme>

--- a/src/main/resources/TrueDarkDunes.theme.json
+++ b/src/main/resources/TrueDarkDunes.theme.json
@@ -1,0 +1,360 @@
+{
+  "name": "True Dark Dunes",
+  "dark": true,
+  "author": "Ahmed Elshaer",
+  "editorScheme": "/TrueDarkDunes.xml",
+  "colors": {
+    "primary": "#121212",
+    "secondary": "#121212",
+    "activeSelection": "#2D2D2D",
+    "inactiveSelection": "#1F1F1F",
+    "borderColor": "#1E1E1E",
+    "separatorColor": "#1F1F1F",
+    "accentColor": "#D2B48C"
+  },
+  "ui": {
+    "*": {
+      "arc": "6",
+      "background": "primary",
+      "selectionBackground": "activeSelection",
+      "selectionInactiveBackground": "inactiveSelection",
+      "disabledBackground": "primary",
+      "underlineColor": "accentColor",
+      "borderColor": "borderColor",
+      "separatorColor": "separatorColor",
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ActionButton": {
+      "hoverBorderColor": "accentColor",
+      "hoverBackground": "secondary",
+      "pressedBorderColor": "accentColor",
+      "pressedBackground": "secondary"
+    },
+    "Bookmark": {
+    },
+    "BookmarkMnemonicAssigned": {
+      "background": "inactiveSelection",
+      "borderColor": "inactiveSelection"
+    },
+    "BookmarkMnemonicCurrent": {
+      "background": "activeSelection",
+      "borderColor": "activeSelection"
+    },
+    "Borders": {
+      "color": "borderColor",
+      "ContrastBorderColor": "borderColor"
+    },
+    "Button": {
+      "foreground": "#D1D1D1",
+      "startBackground": "secondary",
+      "endBackground": "secondary",
+      "focusedBorderColor": "accentColor",
+      "startBorderColor": "inactiveSelection",
+      "endBorderColor": "inactiveSelection",
+      "default": {
+        "foreground": "#FFFFFF",
+        "startBackground": "accentColor",
+        "endBackground": "accentColor",
+        "startBorderColor": "accentColor",
+        "endBorderColor": "accentColor",
+        "focusColor": "accentColor",
+        "focusedBorderColor": "accentColor"
+      }
+    },
+    "Counter": {
+      "foreground": "#D1D1D1"
+    },
+    "TextField": {
+      "background": "primary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ComboBox": {
+      "nonEditableBackground": "secondary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "borderColor": "borderColor",
+      "ArrowButton": {
+        "background": "secondary",
+        "nonEditableBackground": "secondary"
+      }
+    },
+    "CompletionPopup": {
+      "matchForeground": "#fc5fa3",
+      "selectionBackground": "activeSelection",
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "Component": {
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor",
+      "disabledBorderColor": "borderColor"
+    },
+    "Editor": {
+      "shortcutForeground": "accentColor",
+      "background": "secondary",
+      "SearchField.borderColor": "borderColor",
+      "Tooltip.background": "inactiveSelection",
+      "Tooltip.borderColor": "borderColor",
+      "currentLineHighlight.style": "rounded",
+      "lineHighlight.borderRadius": 6,
+      "caretRow.style": "rounded"
+    },
+    "EditorTabs": {
+      "underlinedTabBackground": "primary",
+      "background": "secondary",
+      "underlineHeight": 2,
+      "tabArc": 6,
+      "underlineColor": "accentColor",
+      "selectedBackground": "activeSelection",
+      "selectedForeground": "accentColor",
+      "hoverBackground": "inactiveSelection"
+    },
+    "Link": {
+      "activeForeground": "accentColor",
+      "hoverForeground": "accentColor",
+      "visitedForeground": "#9F7AEA",
+      "pressedForeground": "accentColor"
+    },
+    "LoadingIndicator": {
+      "color": "#A78BFA",
+      "backgroundColor": "primary"
+    },
+    "Spinner": {
+      "background": "secondary",
+      "foreground": "#A78BFA",
+      "selectionForeground": "#C8A8E9"
+    },
+    "ProcessIndicator": {
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9"
+    },
+    "Notification": {
+      "ToolWindow": {
+        "informativeBackground": "primary",
+        "informativeBorderColor": "#42b827",
+        "informativeForeground": "#D1D1D1",
+        "warningBackground": "primary",
+        "errorBackground": "primary"
+      }
+    },
+    "Plugins": {
+      "hoverBackground": "accentColor",
+      "hoverForeground": "#FFFFFF",
+      "lightSelectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "foreground": "#D1D1D1"
+    },
+    "PasswordField": {
+      "background": "secondary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ProgressBar": {
+      "background": "primary",
+      "foreground": "#A78BFA",
+      "selectionBackground": "#B794F6",
+      "selectionForeground": "#C8A8E9",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "progressColor": "#A78BFA",
+      "trackColor": "inactiveSelection",
+      "passedColor": "#B794F6",
+      "passedEndColor": "#C8A8E9"
+    },
+    "SearchMatch": {
+      "startBackground": "#eeed38",
+      "endBackground": "#eeed38"
+    },
+    "SearchEverywhere": {
+      "Tab": {
+        "selectedBackground": "accentColor",
+        "selectedForeground": "#FFFFFF"
+      }
+    },
+    "SidePanel": {
+      "background": "secondary"
+    },
+    "StatusBar": {
+      "hoverBackground": "secondary"
+    },
+    "Table": {
+      "hoverBackground": "inactiveSelection",
+      "lightSelectionBackground": "accentColor",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverForeground": "#D1D1D1",
+      "gridColor": "borderColor"
+    },
+    "TableHeader": {
+      "bottomSeparatorColor": "separatorColor",
+      "borderColor": "borderColor"
+    },
+    "ToggleButton": {
+      "onBackground": "#D1D1D1"
+    },
+    "ToolWindow": {
+      "Button": {
+        "selectedBackground": "secondary"
+      },
+      "Header": {
+        "background": "primary",
+        "inactiveBackground": "secondary"
+      }
+    },
+    "Tree": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "foreground": "#D1D1D1",
+      "rowHeight": 22,
+      "selectionForeground": "#FFFFFF"
+    },
+    "VersionControl": {
+      "Log": {
+        "Commit": {
+          "currentBranchBackground": "accentColor",
+          "hoveredBackground": "inactiveSelection"
+        }
+      }
+    },
+    "WelcomeScreen": {
+      "SidePanel": {
+        "background": "secondary"
+      },
+      "Projects": {
+        "background": "inactiveSelection",
+        "actions": {
+          "background": "inactiveSelection"
+        }
+      }
+    },
+    "FileColor": {
+      "Yellow": "121212",
+      "Green": "121212",
+      "Blue": "121212",
+      "Violet": "121212",
+      "Orange": "121212",
+      "Rose": "121212"
+    },
+    "ProjectView": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "selectionForeground": "#FFFFFF"
+    },
+    "FileColors": {
+      "enabledForTabs": false,
+      "enabledForProjectView": false
+    },
+    "Scope": {
+      "background": "primary"
+    },
+    "Popup": {
+      "background": "primary",
+      "Header.activeBackground": "accentColor",
+      "Header.inactiveBackground": "inactiveSelection",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "Advertiser": {
+        "background": "inactiveSelection",
+        "borderColor": "borderColor"
+      }
+    },
+    "Breadcrumbs": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "hoverBackground": "inactiveSelection",
+      "borderColor": "borderColor",
+      "selectionForeground": "#FFFFFF"
+    },
+    "Menu": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "selectionBackground": "activeSelection"
+    },
+    "CheckBox": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "RadioButton": {
+      "background": "primary", 
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "FormattedTextField": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1"
+    },
+    "TextArea": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TextPane": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TaskProgressBar": {
+      "background": "primary",
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "passedColor": "#B794F6",
+      "trackColor": "inactiveSelection"
+    },
+    "InplaceRefactoringPopup": {
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "AsyncProcessIcon": {
+      "color": "#A78BFA"
+    },
+    "InternalFrameTitlePane": {
+      "background": "secondary",
+      "inactiveBackground": "primary"
+    },
+    "ScrollBar": {
+      "background": "primary",
+      "Thumb": {
+        "background": "inactiveSelection",
+        "hoverBackground": "accentColor",
+        "pressedBackground": "accentColor"
+      },
+      "track": "primary"
+    },
+    "Slider": {
+      "background": "primary",
+      "foreground": "accentColor",
+      "track": "inactiveSelection",
+      "thumb": "accentColor",
+      "focus": "accentColor"
+    },
+    "TabbedPane": {
+      "background": "secondary",
+      "selectedBackground": "accentColor",
+      "selectedForeground": "#FFFFFF",
+      "hoverColor": "inactiveSelection",
+      "focusColor": "accentColor",
+      "underlineColor": "accentColor",
+      "foreground": "#D1D1D1",
+      "hoverForeground": "#D1D1D1"
+    },
+    "List": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverBackground": "inactiveSelection"
+    }
+  }
+}

--- a/src/main/resources/TrueDarkDunes.xml
+++ b/src/main/resources/TrueDarkDunes.xml
@@ -1,0 +1,42 @@
+<scheme name="True Dark Dunes" version="142" parent_scheme="True Dark">
+  <metaInfo>
+    <property name="created">2023-07-18T14:11:44</property>
+    <property name="ide">Idea</property>
+    <property name="ideVersion">231.9161.38</property>
+    <property name="modified">2023-07-18T14:11:44</property>
+    <property name="originalScheme">True Dark</property>
+  </metaInfo>
+  <colors>
+    <option name="LINE_NUMBER_ON_CARET_ROW_COLOR" value="#D2B48C" />
+    <option name="CARET_COLOR" value="#D2B48C" />
+    <option name="SELECTION_BACKGROUND" value="#2D2D2D" />
+  </colors>
+  <attributes>
+    <option name="DEFAULT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="#D2B48C" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_STRING">
+      <value>
+        <option name="FOREGROUND" value="#F0E68C" />
+      </value>
+    </option>
+    <option name="DEFAULT_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="#D4B483" />
+      </value>
+    </option>
+    <option name="DEFAULT_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#A18860" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#C8B699" />
+      </value>
+    </option>
+  </attributes>
+</scheme>

--- a/src/main/resources/TrueDarkForest.theme.json
+++ b/src/main/resources/TrueDarkForest.theme.json
@@ -1,0 +1,360 @@
+{
+  "name": "True Dark Forest",
+  "dark": true,
+  "author": "Ahmed Elshaer",
+  "editorScheme": "/TrueDarkForest.xml",
+  "colors": {
+    "primary": "#121212",
+    "secondary": "#121212",
+    "activeSelection": "#2D2D2D",
+    "inactiveSelection": "#1F1F1F",
+    "borderColor": "#1E1E1E",
+    "separatorColor": "#1F1F1F",
+    "accentColor": "#81C784"
+  },
+  "ui": {
+    "*": {
+      "arc": "6",
+      "background": "primary",
+      "selectionBackground": "activeSelection",
+      "selectionInactiveBackground": "inactiveSelection",
+      "disabledBackground": "primary",
+      "underlineColor": "accentColor",
+      "borderColor": "borderColor",
+      "separatorColor": "separatorColor",
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ActionButton": {
+      "hoverBorderColor": "accentColor",
+      "hoverBackground": "secondary",
+      "pressedBorderColor": "accentColor",
+      "pressedBackground": "secondary"
+    },
+    "Bookmark": {
+    },
+    "BookmarkMnemonicAssigned": {
+      "background": "inactiveSelection",
+      "borderColor": "inactiveSelection"
+    },
+    "BookmarkMnemonicCurrent": {
+      "background": "activeSelection",
+      "borderColor": "activeSelection"
+    },
+    "Borders": {
+      "color": "borderColor",
+      "ContrastBorderColor": "borderColor"
+    },
+    "Button": {
+      "foreground": "#D1D1D1",
+      "startBackground": "secondary",
+      "endBackground": "secondary",
+      "focusedBorderColor": "accentColor",
+      "startBorderColor": "inactiveSelection",
+      "endBorderColor": "inactiveSelection",
+      "default": {
+        "foreground": "#FFFFFF",
+        "startBackground": "accentColor",
+        "endBackground": "accentColor",
+        "startBorderColor": "accentColor",
+        "endBorderColor": "accentColor",
+        "focusColor": "accentColor",
+        "focusedBorderColor": "accentColor"
+      }
+    },
+    "Counter": {
+      "foreground": "#D1D1D1"
+    },
+    "TextField": {
+      "background": "primary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ComboBox": {
+      "nonEditableBackground": "secondary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "borderColor": "borderColor",
+      "ArrowButton": {
+        "background": "secondary",
+        "nonEditableBackground": "secondary"
+      }
+    },
+    "CompletionPopup": {
+      "matchForeground": "#fc5fa3",
+      "selectionBackground": "activeSelection",
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "Component": {
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor",
+      "disabledBorderColor": "borderColor"
+    },
+    "Editor": {
+      "shortcutForeground": "accentColor",
+      "background": "secondary",
+      "SearchField.borderColor": "borderColor",
+      "Tooltip.background": "inactiveSelection",
+      "Tooltip.borderColor": "borderColor",
+      "currentLineHighlight.style": "rounded",
+      "lineHighlight.borderRadius": 6,
+      "caretRow.style": "rounded"
+    },
+    "EditorTabs": {
+      "underlinedTabBackground": "primary",
+      "background": "secondary",
+      "underlineHeight": 2,
+      "tabArc": 6,
+      "underlineColor": "accentColor",
+      "selectedBackground": "activeSelection",
+      "selectedForeground": "accentColor",
+      "hoverBackground": "inactiveSelection"
+    },
+    "Link": {
+      "activeForeground": "accentColor",
+      "hoverForeground": "accentColor",
+      "visitedForeground": "#9F7AEA",
+      "pressedForeground": "accentColor"
+    },
+    "LoadingIndicator": {
+      "color": "#A78BFA",
+      "backgroundColor": "primary"
+    },
+    "Spinner": {
+      "background": "secondary",
+      "foreground": "#A78BFA",
+      "selectionForeground": "#C8A8E9"
+    },
+    "ProcessIndicator": {
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9"
+    },
+    "Notification": {
+      "ToolWindow": {
+        "informativeBackground": "primary",
+        "informativeBorderColor": "#42b827",
+        "informativeForeground": "#D1D1D1",
+        "warningBackground": "primary",
+        "errorBackground": "primary"
+      }
+    },
+    "Plugins": {
+      "hoverBackground": "accentColor",
+      "hoverForeground": "#FFFFFF",
+      "lightSelectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "foreground": "#D1D1D1"
+    },
+    "PasswordField": {
+      "background": "secondary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ProgressBar": {
+      "background": "primary",
+      "foreground": "#A78BFA",
+      "selectionBackground": "#B794F6",
+      "selectionForeground": "#C8A8E9",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "progressColor": "#A78BFA",
+      "trackColor": "inactiveSelection",
+      "passedColor": "#B794F6",
+      "passedEndColor": "#C8A8E9"
+    },
+    "SearchMatch": {
+      "startBackground": "#eeed38",
+      "endBackground": "#eeed38"
+    },
+    "SearchEverywhere": {
+      "Tab": {
+        "selectedBackground": "accentColor",
+        "selectedForeground": "#FFFFFF"
+      }
+    },
+    "SidePanel": {
+      "background": "secondary"
+    },
+    "StatusBar": {
+      "hoverBackground": "secondary"
+    },
+    "Table": {
+      "hoverBackground": "inactiveSelection",
+      "lightSelectionBackground": "accentColor",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverForeground": "#D1D1D1",
+      "gridColor": "borderColor"
+    },
+    "TableHeader": {
+      "bottomSeparatorColor": "separatorColor",
+      "borderColor": "borderColor"
+    },
+    "ToggleButton": {
+      "onBackground": "#D1D1D1"
+    },
+    "ToolWindow": {
+      "Button": {
+        "selectedBackground": "secondary"
+      },
+      "Header": {
+        "background": "primary",
+        "inactiveBackground": "secondary"
+      }
+    },
+    "Tree": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "foreground": "#D1D1D1",
+      "rowHeight": 22,
+      "selectionForeground": "#FFFFFF"
+    },
+    "VersionControl": {
+      "Log": {
+        "Commit": {
+          "currentBranchBackground": "accentColor",
+          "hoveredBackground": "inactiveSelection"
+        }
+      }
+    },
+    "WelcomeScreen": {
+      "SidePanel": {
+        "background": "secondary"
+      },
+      "Projects": {
+        "background": "inactiveSelection",
+        "actions": {
+          "background": "inactiveSelection"
+        }
+      }
+    },
+    "FileColor": {
+      "Yellow": "121212",
+      "Green": "121212",
+      "Blue": "121212",
+      "Violet": "121212",
+      "Orange": "121212",
+      "Rose": "121212"
+    },
+    "ProjectView": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "selectionForeground": "#FFFFFF"
+    },
+    "FileColors": {
+      "enabledForTabs": false,
+      "enabledForProjectView": false
+    },
+    "Scope": {
+      "background": "primary"
+    },
+    "Popup": {
+      "background": "primary",
+      "Header.activeBackground": "accentColor",
+      "Header.inactiveBackground": "inactiveSelection",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "Advertiser": {
+        "background": "inactiveSelection",
+        "borderColor": "borderColor"
+      }
+    },
+    "Breadcrumbs": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "hoverBackground": "inactiveSelection",
+      "borderColor": "borderColor",
+      "selectionForeground": "#FFFFFF"
+    },
+    "Menu": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "selectionBackground": "activeSelection"
+    },
+    "CheckBox": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "RadioButton": {
+      "background": "primary", 
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "FormattedTextField": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1"
+    },
+    "TextArea": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TextPane": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TaskProgressBar": {
+      "background": "primary",
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "passedColor": "#B794F6",
+      "trackColor": "inactiveSelection"
+    },
+    "InplaceRefactoringPopup": {
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "AsyncProcessIcon": {
+      "color": "#A78BFA"
+    },
+    "InternalFrameTitlePane": {
+      "background": "secondary",
+      "inactiveBackground": "primary"
+    },
+    "ScrollBar": {
+      "background": "primary",
+      "Thumb": {
+        "background": "inactiveSelection",
+        "hoverBackground": "accentColor",
+        "pressedBackground": "accentColor"
+      },
+      "track": "primary"
+    },
+    "Slider": {
+      "background": "primary",
+      "foreground": "accentColor",
+      "track": "inactiveSelection",
+      "thumb": "accentColor",
+      "focus": "accentColor"
+    },
+    "TabbedPane": {
+      "background": "secondary",
+      "selectedBackground": "accentColor",
+      "selectedForeground": "#FFFFFF",
+      "hoverColor": "inactiveSelection",
+      "focusColor": "accentColor",
+      "underlineColor": "accentColor",
+      "foreground": "#D1D1D1",
+      "hoverForeground": "#D1D1D1"
+    },
+    "List": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverBackground": "inactiveSelection"
+    }
+  }
+}

--- a/src/main/resources/TrueDarkForest.xml
+++ b/src/main/resources/TrueDarkForest.xml
@@ -1,0 +1,42 @@
+<scheme name="True Dark Forest" version="142" parent_scheme="True Dark">
+  <metaInfo>
+    <property name="created">2023-07-18T14:11:44</property>
+    <property name="ide">Idea</property>
+    <property name="ideVersion">231.9161.38</property>
+    <property name="modified">2023-07-18T14:11:44</property>
+    <property name="originalScheme">True Dark</property>
+  </metaInfo>
+  <colors>
+    <option name="LINE_NUMBER_ON_CARET_ROW_COLOR" value="#81C784" />
+    <option name="CARET_COLOR" value="#81C784" />
+    <option name="SELECTION_BACKGROUND" value="#2D2D2D" />
+  </colors>
+  <attributes>
+    <option name="DEFAULT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="#81C784" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_STRING">
+      <value>
+        <option name="FOREGROUND" value="#A5D6A7" />
+      </value>
+    </option>
+    <option name="DEFAULT_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="#66BB6A" />
+      </value>
+    </option>
+    <option name="DEFAULT_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#4CAF50" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#A0CFA4" />
+      </value>
+    </option>
+  </attributes>
+</scheme>

--- a/src/main/resources/TrueDarkPremium.theme.json
+++ b/src/main/resources/TrueDarkPremium.theme.json
@@ -1,0 +1,360 @@
+{
+  "name": "True Dark Premium",
+  "dark": true,
+  "author": "Ahmed Elshaer",
+  "editorScheme": "/TrueDarkPremium.xml",
+  "colors": {
+    "primary": "#121212",
+    "secondary": "#121212",
+    "activeSelection": "#2D2D2D",
+    "inactiveSelection": "#1F1F1F",
+    "borderColor": "#1E1E1E",
+    "separatorColor": "#1F1F1F",
+    "accentColor": "#FFD700"
+  },
+  "ui": {
+    "*": {
+      "arc": "6",
+      "background": "primary",
+      "selectionBackground": "activeSelection",
+      "selectionInactiveBackground": "inactiveSelection",
+      "disabledBackground": "primary",
+      "underlineColor": "accentColor",
+      "borderColor": "borderColor",
+      "separatorColor": "separatorColor",
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ActionButton": {
+      "hoverBorderColor": "accentColor",
+      "hoverBackground": "secondary",
+      "pressedBorderColor": "accentColor",
+      "pressedBackground": "secondary"
+    },
+    "Bookmark": {
+    },
+    "BookmarkMnemonicAssigned": {
+      "background": "inactiveSelection",
+      "borderColor": "inactiveSelection"
+    },
+    "BookmarkMnemonicCurrent": {
+      "background": "activeSelection",
+      "borderColor": "activeSelection"
+    },
+    "Borders": {
+      "color": "borderColor",
+      "ContrastBorderColor": "borderColor"
+    },
+    "Button": {
+      "foreground": "#D1D1D1",
+      "startBackground": "secondary",
+      "endBackground": "secondary",
+      "focusedBorderColor": "accentColor",
+      "startBorderColor": "inactiveSelection",
+      "endBorderColor": "inactiveSelection",
+      "default": {
+        "foreground": "#FFFFFF",
+        "startBackground": "accentColor",
+        "endBackground": "accentColor",
+        "startBorderColor": "accentColor",
+        "endBorderColor": "accentColor",
+        "focusColor": "accentColor",
+        "focusedBorderColor": "accentColor"
+      }
+    },
+    "Counter": {
+      "foreground": "#D1D1D1"
+    },
+    "TextField": {
+      "background": "primary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ComboBox": {
+      "nonEditableBackground": "secondary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "borderColor": "borderColor",
+      "ArrowButton": {
+        "background": "secondary",
+        "nonEditableBackground": "secondary"
+      }
+    },
+    "CompletionPopup": {
+      "matchForeground": "#fc5fa3",
+      "selectionBackground": "activeSelection",
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "Component": {
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor",
+      "disabledBorderColor": "borderColor"
+    },
+    "Editor": {
+      "shortcutForeground": "accentColor",
+      "background": "secondary",
+      "SearchField.borderColor": "borderColor",
+      "Tooltip.background": "inactiveSelection",
+      "Tooltip.borderColor": "borderColor",
+      "currentLineHighlight.style": "rounded",
+      "lineHighlight.borderRadius": 6,
+      "caretRow.style": "rounded"
+    },
+    "EditorTabs": {
+      "underlinedTabBackground": "primary",
+      "background": "secondary",
+      "underlineHeight": 2,
+      "tabArc": 6,
+      "underlineColor": "accentColor",
+      "selectedBackground": "activeSelection",
+      "selectedForeground": "accentColor",
+      "hoverBackground": "inactiveSelection"
+    },
+    "Link": {
+      "activeForeground": "accentColor",
+      "hoverForeground": "accentColor",
+      "visitedForeground": "#9F7AEA",
+      "pressedForeground": "accentColor"
+    },
+    "LoadingIndicator": {
+      "color": "#A78BFA",
+      "backgroundColor": "primary"
+    },
+    "Spinner": {
+      "background": "secondary",
+      "foreground": "#A78BFA",
+      "selectionForeground": "#C8A8E9"
+    },
+    "ProcessIndicator": {
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9"
+    },
+    "Notification": {
+      "ToolWindow": {
+        "informativeBackground": "primary",
+        "informativeBorderColor": "#42b827",
+        "informativeForeground": "#D1D1D1",
+        "warningBackground": "primary",
+        "errorBackground": "primary"
+      }
+    },
+    "Plugins": {
+      "hoverBackground": "accentColor",
+      "hoverForeground": "#FFFFFF",
+      "lightSelectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "foreground": "#D1D1D1"
+    },
+    "PasswordField": {
+      "background": "secondary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ProgressBar": {
+      "background": "primary",
+      "foreground": "#A78BFA",
+      "selectionBackground": "#B794F6",
+      "selectionForeground": "#C8A8E9",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "progressColor": "#A78BFA",
+      "trackColor": "inactiveSelection",
+      "passedColor": "#B794F6",
+      "passedEndColor": "#C8A8E9"
+    },
+    "SearchMatch": {
+      "startBackground": "#eeed38",
+      "endBackground": "#eeed38"
+    },
+    "SearchEverywhere": {
+      "Tab": {
+        "selectedBackground": "accentColor",
+        "selectedForeground": "#FFFFFF"
+      }
+    },
+    "SidePanel": {
+      "background": "secondary"
+    },
+    "StatusBar": {
+      "hoverBackground": "secondary"
+    },
+    "Table": {
+      "hoverBackground": "inactiveSelection",
+      "lightSelectionBackground": "accentColor",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverForeground": "#D1D1D1",
+      "gridColor": "borderColor"
+    },
+    "TableHeader": {
+      "bottomSeparatorColor": "separatorColor",
+      "borderColor": "borderColor"
+    },
+    "ToggleButton": {
+      "onBackground": "#D1D1D1"
+    },
+    "ToolWindow": {
+      "Button": {
+        "selectedBackground": "secondary"
+      },
+      "Header": {
+        "background": "primary",
+        "inactiveBackground": "secondary"
+      }
+    },
+    "Tree": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "foreground": "#D1D1D1",
+      "rowHeight": 22,
+      "selectionForeground": "#FFFFFF"
+    },
+    "VersionControl": {
+      "Log": {
+        "Commit": {
+          "currentBranchBackground": "accentColor",
+          "hoveredBackground": "inactiveSelection"
+        }
+      }
+    },
+    "WelcomeScreen": {
+      "SidePanel": {
+        "background": "secondary"
+      },
+      "Projects": {
+        "background": "inactiveSelection",
+        "actions": {
+          "background": "inactiveSelection"
+        }
+      }
+    },
+    "FileColor": {
+      "Yellow": "121212",
+      "Green": "121212",
+      "Blue": "121212",
+      "Violet": "121212",
+      "Orange": "121212",
+      "Rose": "121212"
+    },
+    "ProjectView": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "selectionForeground": "#FFFFFF"
+    },
+    "FileColors": {
+      "enabledForTabs": false,
+      "enabledForProjectView": false
+    },
+    "Scope": {
+      "background": "primary"
+    },
+    "Popup": {
+      "background": "primary",
+      "Header.activeBackground": "accentColor",
+      "Header.inactiveBackground": "inactiveSelection",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "Advertiser": {
+        "background": "inactiveSelection",
+        "borderColor": "borderColor"
+      }
+    },
+    "Breadcrumbs": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "hoverBackground": "inactiveSelection",
+      "borderColor": "borderColor",
+      "selectionForeground": "#FFFFFF"
+    },
+    "Menu": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "selectionBackground": "activeSelection"
+    },
+    "CheckBox": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "RadioButton": {
+      "background": "primary", 
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "FormattedTextField": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1"
+    },
+    "TextArea": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TextPane": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TaskProgressBar": {
+      "background": "primary",
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "passedColor": "#B794F6",
+      "trackColor": "inactiveSelection"
+    },
+    "InplaceRefactoringPopup": {
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "AsyncProcessIcon": {
+      "color": "#A78BFA"
+    },
+    "InternalFrameTitlePane": {
+      "background": "secondary",
+      "inactiveBackground": "primary"
+    },
+    "ScrollBar": {
+      "background": "primary",
+      "Thumb": {
+        "background": "inactiveSelection",
+        "hoverBackground": "accentColor",
+        "pressedBackground": "accentColor"
+      },
+      "track": "primary"
+    },
+    "Slider": {
+      "background": "primary",
+      "foreground": "accentColor",
+      "track": "inactiveSelection",
+      "thumb": "accentColor",
+      "focus": "accentColor"
+    },
+    "TabbedPane": {
+      "background": "secondary",
+      "selectedBackground": "accentColor",
+      "selectedForeground": "#FFFFFF",
+      "hoverColor": "inactiveSelection",
+      "focusColor": "accentColor",
+      "underlineColor": "accentColor",
+      "foreground": "#D1D1D1",
+      "hoverForeground": "#D1D1D1"
+    },
+    "List": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverBackground": "inactiveSelection"
+    }
+  }
+}

--- a/src/main/resources/TrueDarkPremium.xml
+++ b/src/main/resources/TrueDarkPremium.xml
@@ -1,0 +1,42 @@
+<scheme name="True Dark Premium" version="142" parent_scheme="True Dark">
+  <metaInfo>
+    <property name="created">2023-07-18T14:11:44</property>
+    <property name="ide">Idea</property>
+    <property name="ideVersion">231.9161.38</property>
+    <property name="modified">2023-07-18T14:11:44</property>
+    <property name="originalScheme">True Dark</property>
+  </metaInfo>
+  <colors>
+    <option name="LINE_NUMBER_ON_CARET_ROW_COLOR" value="#FFD700" />
+    <option name="CARET_COLOR" value="#FFD700" />
+    <option name="SELECTION_BACKGROUND" value="#2D2D2D" />
+  </colors>
+  <attributes>
+    <option name="DEFAULT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="#FFD700" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_STRING">
+      <value>
+        <option name="FOREGROUND" value="#FFF176" />
+      </value>
+    </option>
+    <option name="DEFAULT_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="#FFC107" />
+      </value>
+    </option>
+    <option name="DEFAULT_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#BDB76B" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#F0E68C" />
+      </value>
+    </option>
+  </attributes>
+</scheme>

--- a/src/main/resources/TrueDarkRuby.theme.json
+++ b/src/main/resources/TrueDarkRuby.theme.json
@@ -1,0 +1,360 @@
+{
+  "name": "True Dark Ruby",
+  "dark": true,
+  "author": "Ahmed Elshaer",
+  "editorScheme": "/TrueDarkRuby.xml",
+  "colors": {
+    "primary": "#121212",
+    "secondary": "#121212",
+    "activeSelection": "#2D2D2D",
+    "inactiveSelection": "#1F1F1F",
+    "borderColor": "#1E1E1E",
+    "separatorColor": "#1F1F1F",
+    "accentColor": "#E53935"
+  },
+  "ui": {
+    "*": {
+      "arc": "6",
+      "background": "primary",
+      "selectionBackground": "activeSelection",
+      "selectionInactiveBackground": "inactiveSelection",
+      "disabledBackground": "primary",
+      "underlineColor": "accentColor",
+      "borderColor": "borderColor",
+      "separatorColor": "separatorColor",
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ActionButton": {
+      "hoverBorderColor": "accentColor",
+      "hoverBackground": "secondary",
+      "pressedBorderColor": "accentColor",
+      "pressedBackground": "secondary"
+    },
+    "Bookmark": {
+    },
+    "BookmarkMnemonicAssigned": {
+      "background": "inactiveSelection",
+      "borderColor": "inactiveSelection"
+    },
+    "BookmarkMnemonicCurrent": {
+      "background": "activeSelection",
+      "borderColor": "activeSelection"
+    },
+    "Borders": {
+      "color": "borderColor",
+      "ContrastBorderColor": "borderColor"
+    },
+    "Button": {
+      "foreground": "#D1D1D1",
+      "startBackground": "secondary",
+      "endBackground": "secondary",
+      "focusedBorderColor": "accentColor",
+      "startBorderColor": "inactiveSelection",
+      "endBorderColor": "inactiveSelection",
+      "default": {
+        "foreground": "#FFFFFF",
+        "startBackground": "accentColor",
+        "endBackground": "accentColor",
+        "startBorderColor": "accentColor",
+        "endBorderColor": "accentColor",
+        "focusColor": "accentColor",
+        "focusedBorderColor": "accentColor"
+      }
+    },
+    "Counter": {
+      "foreground": "#D1D1D1"
+    },
+    "TextField": {
+      "background": "primary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ComboBox": {
+      "nonEditableBackground": "secondary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "borderColor": "borderColor",
+      "ArrowButton": {
+        "background": "secondary",
+        "nonEditableBackground": "secondary"
+      }
+    },
+    "CompletionPopup": {
+      "matchForeground": "#fc5fa3",
+      "selectionBackground": "activeSelection",
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "Component": {
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor",
+      "disabledBorderColor": "borderColor"
+    },
+    "Editor": {
+      "shortcutForeground": "accentColor",
+      "background": "secondary",
+      "SearchField.borderColor": "borderColor",
+      "Tooltip.background": "inactiveSelection",
+      "Tooltip.borderColor": "borderColor",
+      "currentLineHighlight.style": "rounded",
+      "lineHighlight.borderRadius": 6,
+      "caretRow.style": "rounded"
+    },
+    "EditorTabs": {
+      "underlinedTabBackground": "primary",
+      "background": "secondary",
+      "underlineHeight": 2,
+      "tabArc": 6,
+      "underlineColor": "accentColor",
+      "selectedBackground": "activeSelection",
+      "selectedForeground": "accentColor",
+      "hoverBackground": "inactiveSelection"
+    },
+    "Link": {
+      "activeForeground": "accentColor",
+      "hoverForeground": "accentColor",
+      "visitedForeground": "#9F7AEA",
+      "pressedForeground": "accentColor"
+    },
+    "LoadingIndicator": {
+      "color": "#A78BFA",
+      "backgroundColor": "primary"
+    },
+    "Spinner": {
+      "background": "secondary",
+      "foreground": "#A78BFA",
+      "selectionForeground": "#C8A8E9"
+    },
+    "ProcessIndicator": {
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9"
+    },
+    "Notification": {
+      "ToolWindow": {
+        "informativeBackground": "primary",
+        "informativeBorderColor": "#42b827",
+        "informativeForeground": "#D1D1D1",
+        "warningBackground": "primary",
+        "errorBackground": "primary"
+      }
+    },
+    "Plugins": {
+      "hoverBackground": "accentColor",
+      "hoverForeground": "#FFFFFF",
+      "lightSelectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "foreground": "#D1D1D1"
+    },
+    "PasswordField": {
+      "background": "secondary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ProgressBar": {
+      "background": "primary",
+      "foreground": "#A78BFA",
+      "selectionBackground": "#B794F6",
+      "selectionForeground": "#C8A8E9",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "progressColor": "#A78BFA",
+      "trackColor": "inactiveSelection",
+      "passedColor": "#B794F6",
+      "passedEndColor": "#C8A8E9"
+    },
+    "SearchMatch": {
+      "startBackground": "#eeed38",
+      "endBackground": "#eeed38"
+    },
+    "SearchEverywhere": {
+      "Tab": {
+        "selectedBackground": "accentColor",
+        "selectedForeground": "#FFFFFF"
+      }
+    },
+    "SidePanel": {
+      "background": "secondary"
+    },
+    "StatusBar": {
+      "hoverBackground": "secondary"
+    },
+    "Table": {
+      "hoverBackground": "inactiveSelection",
+      "lightSelectionBackground": "accentColor",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverForeground": "#D1D1D1",
+      "gridColor": "borderColor"
+    },
+    "TableHeader": {
+      "bottomSeparatorColor": "separatorColor",
+      "borderColor": "borderColor"
+    },
+    "ToggleButton": {
+      "onBackground": "#D1D1D1"
+    },
+    "ToolWindow": {
+      "Button": {
+        "selectedBackground": "secondary"
+      },
+      "Header": {
+        "background": "primary",
+        "inactiveBackground": "secondary"
+      }
+    },
+    "Tree": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "foreground": "#D1D1D1",
+      "rowHeight": 22,
+      "selectionForeground": "#FFFFFF"
+    },
+    "VersionControl": {
+      "Log": {
+        "Commit": {
+          "currentBranchBackground": "accentColor",
+          "hoveredBackground": "inactiveSelection"
+        }
+      }
+    },
+    "WelcomeScreen": {
+      "SidePanel": {
+        "background": "secondary"
+      },
+      "Projects": {
+        "background": "inactiveSelection",
+        "actions": {
+          "background": "inactiveSelection"
+        }
+      }
+    },
+    "FileColor": {
+      "Yellow": "121212",
+      "Green": "121212",
+      "Blue": "121212",
+      "Violet": "121212",
+      "Orange": "121212",
+      "Rose": "121212"
+    },
+    "ProjectView": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "selectionForeground": "#FFFFFF"
+    },
+    "FileColors": {
+      "enabledForTabs": false,
+      "enabledForProjectView": false
+    },
+    "Scope": {
+      "background": "primary"
+    },
+    "Popup": {
+      "background": "primary",
+      "Header.activeBackground": "accentColor",
+      "Header.inactiveBackground": "inactiveSelection",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "Advertiser": {
+        "background": "inactiveSelection",
+        "borderColor": "borderColor"
+      }
+    },
+    "Breadcrumbs": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "hoverBackground": "inactiveSelection",
+      "borderColor": "borderColor",
+      "selectionForeground": "#FFFFFF"
+    },
+    "Menu": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "selectionBackground": "activeSelection"
+    },
+    "CheckBox": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "RadioButton": {
+      "background": "primary", 
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "FormattedTextField": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1"
+    },
+    "TextArea": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TextPane": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TaskProgressBar": {
+      "background": "primary",
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "passedColor": "#B794F6",
+      "trackColor": "inactiveSelection"
+    },
+    "InplaceRefactoringPopup": {
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "AsyncProcessIcon": {
+      "color": "#A78BFA"
+    },
+    "InternalFrameTitlePane": {
+      "background": "secondary",
+      "inactiveBackground": "primary"
+    },
+    "ScrollBar": {
+      "background": "primary",
+      "Thumb": {
+        "background": "inactiveSelection",
+        "hoverBackground": "accentColor",
+        "pressedBackground": "accentColor"
+      },
+      "track": "primary"
+    },
+    "Slider": {
+      "background": "primary",
+      "foreground": "accentColor",
+      "track": "inactiveSelection",
+      "thumb": "accentColor",
+      "focus": "accentColor"
+    },
+    "TabbedPane": {
+      "background": "secondary",
+      "selectedBackground": "accentColor",
+      "selectedForeground": "#FFFFFF",
+      "hoverColor": "inactiveSelection",
+      "focusColor": "accentColor",
+      "underlineColor": "accentColor",
+      "foreground": "#D1D1D1",
+      "hoverForeground": "#D1D1D1"
+    },
+    "List": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverBackground": "inactiveSelection"
+    }
+  }
+}

--- a/src/main/resources/TrueDarkRuby.xml
+++ b/src/main/resources/TrueDarkRuby.xml
@@ -1,0 +1,42 @@
+<scheme name="True Dark Ruby" version="142" parent_scheme="True Dark">
+  <metaInfo>
+    <property name="created">2023-07-18T14:11:44</property>
+    <property name="ide">Idea</property>
+    <property name="ideVersion">231.9161.38</property>
+    <property name="modified">2023-07-18T14:11:44</property>
+    <property name="originalScheme">True Dark</property>
+  </metaInfo>
+  <colors>
+    <option name="LINE_NUMBER_ON_CARET_ROW_COLOR" value="#E53935" />
+    <option name="CARET_COLOR" value="#E53935" />
+    <option name="SELECTION_BACKGROUND" value="#2D2D2D" />
+  </colors>
+  <attributes>
+    <option name="DEFAULT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="#E53935" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_STRING">
+      <value>
+        <option name="FOREGROUND" value="#FF6B6B" />
+      </value>
+    </option>
+    <option name="DEFAULT_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="#FF8A80" />
+      </value>
+    </option>
+    <option name="DEFAULT_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#B71C1C" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#EF9A9A" />
+      </value>
+    </option>
+  </attributes>
+</scheme>

--- a/src/main/resources/TrueDarkSeasonal.theme.json
+++ b/src/main/resources/TrueDarkSeasonal.theme.json
@@ -1,0 +1,360 @@
+{
+  "name": "True Dark Seasonal",
+  "dark": true,
+  "author": "Ahmed Elshaer",
+  "editorScheme": "/TrueDarkSeasonal.xml",
+  "colors": {
+    "primary": "#121212",
+    "secondary": "#121212",
+    "activeSelection": "#2D2D2D",
+    "inactiveSelection": "#1F1F1F",
+    "borderColor": "#1E1E1E",
+    "separatorColor": "#1F1F1F",
+    "accentColor": "#FFB74D"
+  },
+  "ui": {
+    "*": {
+      "arc": "6",
+      "background": "primary",
+      "selectionBackground": "activeSelection",
+      "selectionInactiveBackground": "inactiveSelection",
+      "disabledBackground": "primary",
+      "underlineColor": "accentColor",
+      "borderColor": "borderColor",
+      "separatorColor": "separatorColor",
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ActionButton": {
+      "hoverBorderColor": "accentColor",
+      "hoverBackground": "secondary",
+      "pressedBorderColor": "accentColor",
+      "pressedBackground": "secondary"
+    },
+    "Bookmark": {
+    },
+    "BookmarkMnemonicAssigned": {
+      "background": "inactiveSelection",
+      "borderColor": "inactiveSelection"
+    },
+    "BookmarkMnemonicCurrent": {
+      "background": "activeSelection",
+      "borderColor": "activeSelection"
+    },
+    "Borders": {
+      "color": "borderColor",
+      "ContrastBorderColor": "borderColor"
+    },
+    "Button": {
+      "foreground": "#D1D1D1",
+      "startBackground": "secondary",
+      "endBackground": "secondary",
+      "focusedBorderColor": "accentColor",
+      "startBorderColor": "inactiveSelection",
+      "endBorderColor": "inactiveSelection",
+      "default": {
+        "foreground": "#FFFFFF",
+        "startBackground": "accentColor",
+        "endBackground": "accentColor",
+        "startBorderColor": "accentColor",
+        "endBorderColor": "accentColor",
+        "focusColor": "accentColor",
+        "focusedBorderColor": "accentColor"
+      }
+    },
+    "Counter": {
+      "foreground": "#D1D1D1"
+    },
+    "TextField": {
+      "background": "primary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ComboBox": {
+      "nonEditableBackground": "secondary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "borderColor": "borderColor",
+      "ArrowButton": {
+        "background": "secondary",
+        "nonEditableBackground": "secondary"
+      }
+    },
+    "CompletionPopup": {
+      "matchForeground": "#fc5fa3",
+      "selectionBackground": "activeSelection",
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "Component": {
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor",
+      "disabledBorderColor": "borderColor"
+    },
+    "Editor": {
+      "shortcutForeground": "accentColor",
+      "background": "secondary",
+      "SearchField.borderColor": "borderColor",
+      "Tooltip.background": "inactiveSelection",
+      "Tooltip.borderColor": "borderColor",
+      "currentLineHighlight.style": "rounded",
+      "lineHighlight.borderRadius": 6,
+      "caretRow.style": "rounded"
+    },
+    "EditorTabs": {
+      "underlinedTabBackground": "primary",
+      "background": "secondary",
+      "underlineHeight": 2,
+      "tabArc": 6,
+      "underlineColor": "accentColor",
+      "selectedBackground": "activeSelection",
+      "selectedForeground": "accentColor",
+      "hoverBackground": "inactiveSelection"
+    },
+    "Link": {
+      "activeForeground": "accentColor",
+      "hoverForeground": "accentColor",
+      "visitedForeground": "#9F7AEA",
+      "pressedForeground": "accentColor"
+    },
+    "LoadingIndicator": {
+      "color": "#A78BFA",
+      "backgroundColor": "primary"
+    },
+    "Spinner": {
+      "background": "secondary",
+      "foreground": "#A78BFA",
+      "selectionForeground": "#C8A8E9"
+    },
+    "ProcessIndicator": {
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9"
+    },
+    "Notification": {
+      "ToolWindow": {
+        "informativeBackground": "primary",
+        "informativeBorderColor": "#42b827",
+        "informativeForeground": "#D1D1D1",
+        "warningBackground": "primary",
+        "errorBackground": "primary"
+      }
+    },
+    "Plugins": {
+      "hoverBackground": "accentColor",
+      "hoverForeground": "#FFFFFF",
+      "lightSelectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "foreground": "#D1D1D1"
+    },
+    "PasswordField": {
+      "background": "secondary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ProgressBar": {
+      "background": "primary",
+      "foreground": "#A78BFA",
+      "selectionBackground": "#B794F6",
+      "selectionForeground": "#C8A8E9",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "progressColor": "#A78BFA",
+      "trackColor": "inactiveSelection",
+      "passedColor": "#B794F6",
+      "passedEndColor": "#C8A8E9"
+    },
+    "SearchMatch": {
+      "startBackground": "#eeed38",
+      "endBackground": "#eeed38"
+    },
+    "SearchEverywhere": {
+      "Tab": {
+        "selectedBackground": "accentColor",
+        "selectedForeground": "#FFFFFF"
+      }
+    },
+    "SidePanel": {
+      "background": "secondary"
+    },
+    "StatusBar": {
+      "hoverBackground": "secondary"
+    },
+    "Table": {
+      "hoverBackground": "inactiveSelection",
+      "lightSelectionBackground": "accentColor",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverForeground": "#D1D1D1",
+      "gridColor": "borderColor"
+    },
+    "TableHeader": {
+      "bottomSeparatorColor": "separatorColor",
+      "borderColor": "borderColor"
+    },
+    "ToggleButton": {
+      "onBackground": "#D1D1D1"
+    },
+    "ToolWindow": {
+      "Button": {
+        "selectedBackground": "secondary"
+      },
+      "Header": {
+        "background": "primary",
+        "inactiveBackground": "secondary"
+      }
+    },
+    "Tree": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "foreground": "#D1D1D1",
+      "rowHeight": 22,
+      "selectionForeground": "#FFFFFF"
+    },
+    "VersionControl": {
+      "Log": {
+        "Commit": {
+          "currentBranchBackground": "accentColor",
+          "hoveredBackground": "inactiveSelection"
+        }
+      }
+    },
+    "WelcomeScreen": {
+      "SidePanel": {
+        "background": "secondary"
+      },
+      "Projects": {
+        "background": "inactiveSelection",
+        "actions": {
+          "background": "inactiveSelection"
+        }
+      }
+    },
+    "FileColor": {
+      "Yellow": "121212",
+      "Green": "121212",
+      "Blue": "121212",
+      "Violet": "121212",
+      "Orange": "121212",
+      "Rose": "121212"
+    },
+    "ProjectView": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "selectionForeground": "#FFFFFF"
+    },
+    "FileColors": {
+      "enabledForTabs": false,
+      "enabledForProjectView": false
+    },
+    "Scope": {
+      "background": "primary"
+    },
+    "Popup": {
+      "background": "primary",
+      "Header.activeBackground": "accentColor",
+      "Header.inactiveBackground": "inactiveSelection",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "Advertiser": {
+        "background": "inactiveSelection",
+        "borderColor": "borderColor"
+      }
+    },
+    "Breadcrumbs": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "hoverBackground": "inactiveSelection",
+      "borderColor": "borderColor",
+      "selectionForeground": "#FFFFFF"
+    },
+    "Menu": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "selectionBackground": "activeSelection"
+    },
+    "CheckBox": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "RadioButton": {
+      "background": "primary", 
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "FormattedTextField": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1"
+    },
+    "TextArea": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TextPane": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TaskProgressBar": {
+      "background": "primary",
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "passedColor": "#B794F6",
+      "trackColor": "inactiveSelection"
+    },
+    "InplaceRefactoringPopup": {
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "AsyncProcessIcon": {
+      "color": "#A78BFA"
+    },
+    "InternalFrameTitlePane": {
+      "background": "secondary",
+      "inactiveBackground": "primary"
+    },
+    "ScrollBar": {
+      "background": "primary",
+      "Thumb": {
+        "background": "inactiveSelection",
+        "hoverBackground": "accentColor",
+        "pressedBackground": "accentColor"
+      },
+      "track": "primary"
+    },
+    "Slider": {
+      "background": "primary",
+      "foreground": "accentColor",
+      "track": "inactiveSelection",
+      "thumb": "accentColor",
+      "focus": "accentColor"
+    },
+    "TabbedPane": {
+      "background": "secondary",
+      "selectedBackground": "accentColor",
+      "selectedForeground": "#FFFFFF",
+      "hoverColor": "inactiveSelection",
+      "focusColor": "accentColor",
+      "underlineColor": "accentColor",
+      "foreground": "#D1D1D1",
+      "hoverForeground": "#D1D1D1"
+    },
+    "List": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverBackground": "inactiveSelection"
+    }
+  }
+}

--- a/src/main/resources/TrueDarkSeasonal.xml
+++ b/src/main/resources/TrueDarkSeasonal.xml
@@ -1,0 +1,42 @@
+<scheme name="True Dark Seasonal" version="142" parent_scheme="True Dark">
+  <metaInfo>
+    <property name="created">2023-07-18T14:11:44</property>
+    <property name="ide">Idea</property>
+    <property name="ideVersion">231.9161.38</property>
+    <property name="modified">2023-07-18T14:11:44</property>
+    <property name="originalScheme">True Dark</property>
+  </metaInfo>
+  <colors>
+    <option name="LINE_NUMBER_ON_CARET_ROW_COLOR" value="#FFB74D" />
+    <option name="CARET_COLOR" value="#FFB74D" />
+    <option name="SELECTION_BACKGROUND" value="#2D2D2D" />
+  </colors>
+  <attributes>
+    <option name="DEFAULT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="#FFB74D" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_STRING">
+      <value>
+        <option name="FOREGROUND" value="#81C784" />
+      </value>
+    </option>
+    <option name="DEFAULT_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="#4FC3F7" />
+      </value>
+    </option>
+    <option name="DEFAULT_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#E57373" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#A1887F" />
+      </value>
+    </option>
+  </attributes>
+</scheme>

--- a/src/main/resources/TrueDarkSpace.theme.json
+++ b/src/main/resources/TrueDarkSpace.theme.json
@@ -1,0 +1,360 @@
+{
+  "name": "True Dark Space",
+  "dark": true,
+  "author": "Ahmed Elshaer",
+  "editorScheme": "/TrueDarkSpace.xml",
+  "colors": {
+    "primary": "#121212",
+    "secondary": "#121212",
+    "activeSelection": "#2D2D2D",
+    "inactiveSelection": "#1F1F1F",
+    "borderColor": "#1E1E1E",
+    "separatorColor": "#1F1F1F",
+    "accentColor": "#90CAF9"
+  },
+  "ui": {
+    "*": {
+      "arc": "6",
+      "background": "primary",
+      "selectionBackground": "activeSelection",
+      "selectionInactiveBackground": "inactiveSelection",
+      "disabledBackground": "primary",
+      "underlineColor": "accentColor",
+      "borderColor": "borderColor",
+      "separatorColor": "separatorColor",
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ActionButton": {
+      "hoverBorderColor": "accentColor",
+      "hoverBackground": "secondary",
+      "pressedBorderColor": "accentColor",
+      "pressedBackground": "secondary"
+    },
+    "Bookmark": {
+    },
+    "BookmarkMnemonicAssigned": {
+      "background": "inactiveSelection",
+      "borderColor": "inactiveSelection"
+    },
+    "BookmarkMnemonicCurrent": {
+      "background": "activeSelection",
+      "borderColor": "activeSelection"
+    },
+    "Borders": {
+      "color": "borderColor",
+      "ContrastBorderColor": "borderColor"
+    },
+    "Button": {
+      "foreground": "#D1D1D1",
+      "startBackground": "secondary",
+      "endBackground": "secondary",
+      "focusedBorderColor": "accentColor",
+      "startBorderColor": "inactiveSelection",
+      "endBorderColor": "inactiveSelection",
+      "default": {
+        "foreground": "#FFFFFF",
+        "startBackground": "accentColor",
+        "endBackground": "accentColor",
+        "startBorderColor": "accentColor",
+        "endBorderColor": "accentColor",
+        "focusColor": "accentColor",
+        "focusedBorderColor": "accentColor"
+      }
+    },
+    "Counter": {
+      "foreground": "#D1D1D1"
+    },
+    "TextField": {
+      "background": "primary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ComboBox": {
+      "nonEditableBackground": "secondary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "borderColor": "borderColor",
+      "ArrowButton": {
+        "background": "secondary",
+        "nonEditableBackground": "secondary"
+      }
+    },
+    "CompletionPopup": {
+      "matchForeground": "#fc5fa3",
+      "selectionBackground": "activeSelection",
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "Component": {
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor",
+      "disabledBorderColor": "borderColor"
+    },
+    "Editor": {
+      "shortcutForeground": "accentColor",
+      "background": "secondary",
+      "SearchField.borderColor": "borderColor",
+      "Tooltip.background": "inactiveSelection",
+      "Tooltip.borderColor": "borderColor",
+      "currentLineHighlight.style": "rounded",
+      "lineHighlight.borderRadius": 6,
+      "caretRow.style": "rounded"
+    },
+    "EditorTabs": {
+      "underlinedTabBackground": "primary",
+      "background": "secondary",
+      "underlineHeight": 2,
+      "tabArc": 6,
+      "underlineColor": "accentColor",
+      "selectedBackground": "activeSelection",
+      "selectedForeground": "accentColor",
+      "hoverBackground": "inactiveSelection"
+    },
+    "Link": {
+      "activeForeground": "accentColor",
+      "hoverForeground": "accentColor",
+      "visitedForeground": "#9F7AEA",
+      "pressedForeground": "accentColor"
+    },
+    "LoadingIndicator": {
+      "color": "#A78BFA",
+      "backgroundColor": "primary"
+    },
+    "Spinner": {
+      "background": "secondary",
+      "foreground": "#A78BFA",
+      "selectionForeground": "#C8A8E9"
+    },
+    "ProcessIndicator": {
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9"
+    },
+    "Notification": {
+      "ToolWindow": {
+        "informativeBackground": "primary",
+        "informativeBorderColor": "#42b827",
+        "informativeForeground": "#D1D1D1",
+        "warningBackground": "primary",
+        "errorBackground": "primary"
+      }
+    },
+    "Plugins": {
+      "hoverBackground": "accentColor",
+      "hoverForeground": "#FFFFFF",
+      "lightSelectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "foreground": "#D1D1D1"
+    },
+    "PasswordField": {
+      "background": "secondary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ProgressBar": {
+      "background": "primary",
+      "foreground": "#A78BFA",
+      "selectionBackground": "#B794F6",
+      "selectionForeground": "#C8A8E9",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "progressColor": "#A78BFA",
+      "trackColor": "inactiveSelection",
+      "passedColor": "#B794F6",
+      "passedEndColor": "#C8A8E9"
+    },
+    "SearchMatch": {
+      "startBackground": "#eeed38",
+      "endBackground": "#eeed38"
+    },
+    "SearchEverywhere": {
+      "Tab": {
+        "selectedBackground": "accentColor",
+        "selectedForeground": "#FFFFFF"
+      }
+    },
+    "SidePanel": {
+      "background": "secondary"
+    },
+    "StatusBar": {
+      "hoverBackground": "secondary"
+    },
+    "Table": {
+      "hoverBackground": "inactiveSelection",
+      "lightSelectionBackground": "accentColor",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverForeground": "#D1D1D1",
+      "gridColor": "borderColor"
+    },
+    "TableHeader": {
+      "bottomSeparatorColor": "separatorColor",
+      "borderColor": "borderColor"
+    },
+    "ToggleButton": {
+      "onBackground": "#D1D1D1"
+    },
+    "ToolWindow": {
+      "Button": {
+        "selectedBackground": "secondary"
+      },
+      "Header": {
+        "background": "primary",
+        "inactiveBackground": "secondary"
+      }
+    },
+    "Tree": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "foreground": "#D1D1D1",
+      "rowHeight": 22,
+      "selectionForeground": "#FFFFFF"
+    },
+    "VersionControl": {
+      "Log": {
+        "Commit": {
+          "currentBranchBackground": "accentColor",
+          "hoveredBackground": "inactiveSelection"
+        }
+      }
+    },
+    "WelcomeScreen": {
+      "SidePanel": {
+        "background": "secondary"
+      },
+      "Projects": {
+        "background": "inactiveSelection",
+        "actions": {
+          "background": "inactiveSelection"
+        }
+      }
+    },
+    "FileColor": {
+      "Yellow": "121212",
+      "Green": "121212",
+      "Blue": "121212",
+      "Violet": "121212",
+      "Orange": "121212",
+      "Rose": "121212"
+    },
+    "ProjectView": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "selectionForeground": "#FFFFFF"
+    },
+    "FileColors": {
+      "enabledForTabs": false,
+      "enabledForProjectView": false
+    },
+    "Scope": {
+      "background": "primary"
+    },
+    "Popup": {
+      "background": "primary",
+      "Header.activeBackground": "accentColor",
+      "Header.inactiveBackground": "inactiveSelection",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "Advertiser": {
+        "background": "inactiveSelection",
+        "borderColor": "borderColor"
+      }
+    },
+    "Breadcrumbs": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "hoverBackground": "inactiveSelection",
+      "borderColor": "borderColor",
+      "selectionForeground": "#FFFFFF"
+    },
+    "Menu": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "selectionBackground": "activeSelection"
+    },
+    "CheckBox": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "RadioButton": {
+      "background": "primary", 
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "FormattedTextField": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1"
+    },
+    "TextArea": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TextPane": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TaskProgressBar": {
+      "background": "primary",
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "passedColor": "#B794F6",
+      "trackColor": "inactiveSelection"
+    },
+    "InplaceRefactoringPopup": {
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "AsyncProcessIcon": {
+      "color": "#A78BFA"
+    },
+    "InternalFrameTitlePane": {
+      "background": "secondary",
+      "inactiveBackground": "primary"
+    },
+    "ScrollBar": {
+      "background": "primary",
+      "Thumb": {
+        "background": "inactiveSelection",
+        "hoverBackground": "accentColor",
+        "pressedBackground": "accentColor"
+      },
+      "track": "primary"
+    },
+    "Slider": {
+      "background": "primary",
+      "foreground": "accentColor",
+      "track": "inactiveSelection",
+      "thumb": "accentColor",
+      "focus": "accentColor"
+    },
+    "TabbedPane": {
+      "background": "secondary",
+      "selectedBackground": "accentColor",
+      "selectedForeground": "#FFFFFF",
+      "hoverColor": "inactiveSelection",
+      "focusColor": "accentColor",
+      "underlineColor": "accentColor",
+      "foreground": "#D1D1D1",
+      "hoverForeground": "#D1D1D1"
+    },
+    "List": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverBackground": "inactiveSelection"
+    }
+  }
+}

--- a/src/main/resources/TrueDarkSpace.xml
+++ b/src/main/resources/TrueDarkSpace.xml
@@ -1,0 +1,42 @@
+<scheme name="True Dark Space" version="142" parent_scheme="True Dark">
+  <metaInfo>
+    <property name="created">2023-07-18T14:11:44</property>
+    <property name="ide">Idea</property>
+    <property name="ideVersion">231.9161.38</property>
+    <property name="modified">2023-07-18T14:11:44</property>
+    <property name="originalScheme">True Dark</property>
+  </metaInfo>
+  <colors>
+    <option name="LINE_NUMBER_ON_CARET_ROW_COLOR" value="#90CAF9" />
+    <option name="CARET_COLOR" value="#90CAF9" />
+    <option name="SELECTION_BACKGROUND" value="#2D2D2D" />
+  </colors>
+  <attributes>
+    <option name="DEFAULT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="#90CAF9" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_STRING">
+      <value>
+        <option name="FOREGROUND" value="#AAB6FE" />
+      </value>
+    </option>
+    <option name="DEFAULT_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="#CE93D8" />
+      </value>
+    </option>
+    <option name="DEFAULT_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#B0BEC5" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#90A4AE" />
+      </value>
+    </option>
+  </attributes>
+</scheme>

--- a/src/main/resources/TrueDarkWarm.theme.json
+++ b/src/main/resources/TrueDarkWarm.theme.json
@@ -1,0 +1,360 @@
+{
+  "name": "True Dark Warm",
+  "dark": true,
+  "author": "Ahmed Elshaer",
+  "editorScheme": "/TrueDarkWarm.xml",
+  "colors": {
+    "primary": "#121212",
+    "secondary": "#121212",
+    "activeSelection": "#2D2D2D",
+    "inactiveSelection": "#1F1F1F",
+    "borderColor": "#1E1E1E",
+    "separatorColor": "#1F1F1F",
+    "accentColor": "#FF8A65"
+  },
+  "ui": {
+    "*": {
+      "arc": "6",
+      "background": "primary",
+      "selectionBackground": "activeSelection",
+      "selectionInactiveBackground": "inactiveSelection",
+      "disabledBackground": "primary",
+      "underlineColor": "accentColor",
+      "borderColor": "borderColor",
+      "separatorColor": "separatorColor",
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ActionButton": {
+      "hoverBorderColor": "accentColor",
+      "hoverBackground": "secondary",
+      "pressedBorderColor": "accentColor",
+      "pressedBackground": "secondary"
+    },
+    "Bookmark": {
+    },
+    "BookmarkMnemonicAssigned": {
+      "background": "inactiveSelection",
+      "borderColor": "inactiveSelection"
+    },
+    "BookmarkMnemonicCurrent": {
+      "background": "activeSelection",
+      "borderColor": "activeSelection"
+    },
+    "Borders": {
+      "color": "borderColor",
+      "ContrastBorderColor": "borderColor"
+    },
+    "Button": {
+      "foreground": "#D1D1D1",
+      "startBackground": "secondary",
+      "endBackground": "secondary",
+      "focusedBorderColor": "accentColor",
+      "startBorderColor": "inactiveSelection",
+      "endBorderColor": "inactiveSelection",
+      "default": {
+        "foreground": "#FFFFFF",
+        "startBackground": "accentColor",
+        "endBackground": "accentColor",
+        "startBorderColor": "accentColor",
+        "endBorderColor": "accentColor",
+        "focusColor": "accentColor",
+        "focusedBorderColor": "accentColor"
+      }
+    },
+    "Counter": {
+      "foreground": "#D1D1D1"
+    },
+    "TextField": {
+      "background": "primary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ComboBox": {
+      "nonEditableBackground": "secondary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "borderColor": "borderColor",
+      "ArrowButton": {
+        "background": "secondary",
+        "nonEditableBackground": "secondary"
+      }
+    },
+    "CompletionPopup": {
+      "matchForeground": "#fc5fa3",
+      "selectionBackground": "activeSelection",
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "Component": {
+      "focusColor": "accentColor",
+      "focusedBorderColor": "accentColor",
+      "disabledBorderColor": "borderColor"
+    },
+    "Editor": {
+      "shortcutForeground": "accentColor",
+      "background": "secondary",
+      "SearchField.borderColor": "borderColor",
+      "Tooltip.background": "inactiveSelection",
+      "Tooltip.borderColor": "borderColor",
+      "currentLineHighlight.style": "rounded",
+      "lineHighlight.borderRadius": 6,
+      "caretRow.style": "rounded"
+    },
+    "EditorTabs": {
+      "underlinedTabBackground": "primary",
+      "background": "secondary",
+      "underlineHeight": 2,
+      "tabArc": 6,
+      "underlineColor": "accentColor",
+      "selectedBackground": "activeSelection",
+      "selectedForeground": "accentColor",
+      "hoverBackground": "inactiveSelection"
+    },
+    "Link": {
+      "activeForeground": "accentColor",
+      "hoverForeground": "accentColor",
+      "visitedForeground": "#9F7AEA",
+      "pressedForeground": "accentColor"
+    },
+    "LoadingIndicator": {
+      "color": "#A78BFA",
+      "backgroundColor": "primary"
+    },
+    "Spinner": {
+      "background": "secondary",
+      "foreground": "#A78BFA",
+      "selectionForeground": "#C8A8E9"
+    },
+    "ProcessIndicator": {
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9"
+    },
+    "Notification": {
+      "ToolWindow": {
+        "informativeBackground": "primary",
+        "informativeBorderColor": "#42b827",
+        "informativeForeground": "#D1D1D1",
+        "warningBackground": "primary",
+        "errorBackground": "primary"
+      }
+    },
+    "Plugins": {
+      "hoverBackground": "accentColor",
+      "hoverForeground": "#FFFFFF",
+      "lightSelectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "foreground": "#D1D1D1"
+    },
+    "PasswordField": {
+      "background": "secondary",
+      "borderColor": "borderColor",
+      "focusedBorderColor": "accentColor"
+    },
+    "ProgressBar": {
+      "background": "primary",
+      "foreground": "#A78BFA",
+      "selectionBackground": "#B794F6",
+      "selectionForeground": "#C8A8E9",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "progressColor": "#A78BFA",
+      "trackColor": "inactiveSelection",
+      "passedColor": "#B794F6",
+      "passedEndColor": "#C8A8E9"
+    },
+    "SearchMatch": {
+      "startBackground": "#eeed38",
+      "endBackground": "#eeed38"
+    },
+    "SearchEverywhere": {
+      "Tab": {
+        "selectedBackground": "accentColor",
+        "selectedForeground": "#FFFFFF"
+      }
+    },
+    "SidePanel": {
+      "background": "secondary"
+    },
+    "StatusBar": {
+      "hoverBackground": "secondary"
+    },
+    "Table": {
+      "hoverBackground": "inactiveSelection",
+      "lightSelectionBackground": "accentColor",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverForeground": "#D1D1D1",
+      "gridColor": "borderColor"
+    },
+    "TableHeader": {
+      "bottomSeparatorColor": "separatorColor",
+      "borderColor": "borderColor"
+    },
+    "ToggleButton": {
+      "onBackground": "#D1D1D1"
+    },
+    "ToolWindow": {
+      "Button": {
+        "selectedBackground": "secondary"
+      },
+      "Header": {
+        "background": "primary",
+        "inactiveBackground": "secondary"
+      }
+    },
+    "Tree": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "foreground": "#D1D1D1",
+      "rowHeight": 22,
+      "selectionForeground": "#FFFFFF"
+    },
+    "VersionControl": {
+      "Log": {
+        "Commit": {
+          "currentBranchBackground": "accentColor",
+          "hoveredBackground": "inactiveSelection"
+        }
+      }
+    },
+    "WelcomeScreen": {
+      "SidePanel": {
+        "background": "secondary"
+      },
+      "Projects": {
+        "background": "inactiveSelection",
+        "actions": {
+          "background": "inactiveSelection"
+        }
+      }
+    },
+    "FileColor": {
+      "Yellow": "121212",
+      "Green": "121212",
+      "Blue": "121212",
+      "Violet": "121212",
+      "Orange": "121212",
+      "Rose": "121212"
+    },
+    "ProjectView": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "selectionInactiveBackground": "inactiveSelection",
+      "selectionForeground": "#FFFFFF"
+    },
+    "FileColors": {
+      "enabledForTabs": false,
+      "enabledForProjectView": false
+    },
+    "Scope": {
+      "background": "primary"
+    },
+    "Popup": {
+      "background": "primary",
+      "Header.activeBackground": "accentColor",
+      "Header.inactiveBackground": "inactiveSelection",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "Advertiser": {
+        "background": "inactiveSelection",
+        "borderColor": "borderColor"
+      }
+    },
+    "Breadcrumbs": {
+      "background": "primary",
+      "selectionBackground": "accentColor",
+      "hoverBackground": "inactiveSelection",
+      "borderColor": "borderColor",
+      "selectionForeground": "#FFFFFF"
+    },
+    "Menu": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "separatorColor": "borderColor",
+      "borderColor": "borderColor",
+      "selectionBackground": "activeSelection"
+    },
+    "CheckBox": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "RadioButton": {
+      "background": "primary", 
+      "foreground": "#D1D1D1",
+      "select": "#D1D1D1"
+    },
+    "FormattedTextField": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1"
+    },
+    "TextArea": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TextPane": {
+      "background": "secondary",
+      "caretForeground": "#D1D1D1",
+      "selectionBackground": "activeSelection",
+      "borderColor": "borderColor"
+    },
+    "TaskProgressBar": {
+      "background": "primary",
+      "progressColor": "#A78BFA",
+      "indeterminateStartColor": "#9F7AEA",
+      "indeterminateEndColor": "#C8A8E9",
+      "passedColor": "#B794F6",
+      "trackColor": "inactiveSelection"
+    },
+    "InplaceRefactoringPopup": {
+      "background": "primary",
+      "borderColor": "borderColor"
+    },
+    "AsyncProcessIcon": {
+      "color": "#A78BFA"
+    },
+    "InternalFrameTitlePane": {
+      "background": "secondary",
+      "inactiveBackground": "primary"
+    },
+    "ScrollBar": {
+      "background": "primary",
+      "Thumb": {
+        "background": "inactiveSelection",
+        "hoverBackground": "accentColor",
+        "pressedBackground": "accentColor"
+      },
+      "track": "primary"
+    },
+    "Slider": {
+      "background": "primary",
+      "foreground": "accentColor",
+      "track": "inactiveSelection",
+      "thumb": "accentColor",
+      "focus": "accentColor"
+    },
+    "TabbedPane": {
+      "background": "secondary",
+      "selectedBackground": "accentColor",
+      "selectedForeground": "#FFFFFF",
+      "hoverColor": "inactiveSelection",
+      "focusColor": "accentColor",
+      "underlineColor": "accentColor",
+      "foreground": "#D1D1D1",
+      "hoverForeground": "#D1D1D1"
+    },
+    "List": {
+      "background": "primary",
+      "foreground": "#D1D1D1",
+      "selectionBackground": "accentColor",
+      "selectionForeground": "#FFFFFF",
+      "hoverBackground": "inactiveSelection"
+    }
+  }
+}

--- a/src/main/resources/TrueDarkWarm.xml
+++ b/src/main/resources/TrueDarkWarm.xml
@@ -1,0 +1,42 @@
+<scheme name="True Dark Warm" version="142" parent_scheme="True Dark">
+  <metaInfo>
+    <property name="created">2023-07-18T14:11:44</property>
+    <property name="ide">Idea</property>
+    <property name="ideVersion">231.9161.38</property>
+    <property name="modified">2023-07-18T14:11:44</property>
+    <property name="originalScheme">True Dark</property>
+  </metaInfo>
+  <colors>
+    <option name="LINE_NUMBER_ON_CARET_ROW_COLOR" value="#FF8A65" />
+    <option name="CARET_COLOR" value="#FF8A65" />
+    <option name="SELECTION_BACKGROUND" value="#2D2D2D" />
+  </colors>
+  <attributes>
+    <option name="DEFAULT_KEYWORD">
+      <value>
+        <option name="FOREGROUND" value="#FF8A65" />
+        <option name="FONT_TYPE" value="1" />
+      </value>
+    </option>
+    <option name="DEFAULT_STRING">
+      <value>
+        <option name="FOREGROUND" value="#FFB78A" />
+      </value>
+    </option>
+    <option name="DEFAULT_NUMBER">
+      <value>
+        <option name="FOREGROUND" value="#FFD180" />
+      </value>
+    </option>
+    <option name="DEFAULT_LINE_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#B48A72" />
+      </value>
+    </option>
+    <option name="DEFAULT_DOC_COMMENT">
+      <value>
+        <option name="FOREGROUND" value="#BD9080" />
+      </value>
+    </option>
+  </attributes>
+</scheme>


### PR DESCRIPTION
## Summary
- expand premium theme color schemes with full syntax colors
- note that keywords and comments are tinted in README

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_b_68402ea6e3b483248a8b752097d617af